### PR TITLE
Crew sounds simple complex rework

### DIFF
--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -640,7 +640,7 @@
           </Package>
         </Packages>
       </Package>
-      <Package PackageName="Sounds_CrewVoices_English" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lr70rss3bzqwwx8o" Name="English Crew Voices" Type="single1" Visible="True">
+      <Package PackageName="Sounds_CrewVoices_English" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lr70rss3bzqwwx8o" Name="English" Type="single1" Visible="True">
         <Packages>
           <Package PackageName="Sounds_CrewVoices_English_Basic" Enabled="True" InstallGroup="4" PatchGroup="4" UID="1ca3pf40usxremun" Name="Basic" Type="single1" Visible="True">
             <Packages>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -836,7 +836,7 @@
           </Package>
           <Package PackageName="Sounds_CrewVoices_English_Advanced" Enabled="True" InstallGroup="4" PatchGroup="4" UID="isfopklgm7kttpte" Name="Advanced" Type="single1" Visible="True">
             <Packages>
-              <Package PackageName="Sounds_CrewVoices_English_MLGbase" Enabled="False" InstallGroup="4" PatchGroup="4" UID="jrd9z1mss610umir" Name="MLG Mod by Aimdrol (English sound and text)" Type="single1" Visible="True">
+              <Package PackageName="Sounds_CrewVoices_English_MLGbase" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jrd9z1mss610umir" Name="MLG Mod by Aimdrol (English sound and text)" Type="single1" Visible="True">
                 <Size>26113309</Size>
                 <ZipFile>Sounds_mlg_mod_voice_1.7.1.0_2020-01-29.zip</ZipFile>
                 <CRC>0fa8fc8fe27c70bc966f480cde9cd8b1</CRC>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -614,39 +614,46 @@
       <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
     </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_Engines_AGQJv1FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ [by {author}]" Type="single_dropdown1" Visible="True">
-        <Size>22014</Size>
-        <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_Engines_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>f</CRC>
-        <Timestamp>132353110299441130</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
-        <Author>Fedor Saveliev</Author>
-        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <Dependencies>
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Engines_AGQJv2SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ v{version} [by {author}]" Type="single_dropdown1" Visible="True">
-        <Size>8141</Size>
+      <Package PackageName="Sounds_Engines_AGQJ" Enabled="True" InstallGroup="4" PatchGroup="2" UID="5dmxfmdt2b0lnhm2" Name="AGQJ v{version}" Type="single1" Visible="False">
+        <Size>83686458</Size>
         <Version>234</Version>
-        <ZipFile>Sounds_Engines_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <ZipFile>Sounds_Engines_AGQJ_v234_1.9.0.0_2020-04-23.zip</ZipFile>
         <CRC>f</CRC>
-        <Timestamp>132353109714656692</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
-        <Author>SicFunzler</Author>
-        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <UpdateComment>T10 Fix"V-12-6": \r\n{                "wwsoundPC": "V_12P",\r\n                "wwsoundNPC": "V_12P_NPC"           },\r\n\r\nUpdate  G&amp;M  V230  ( 04.03.2020 )</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
+        <Timestamp>132353241358271460</Timestamp>
+        <Packages>
+          <Package PackageName="Sounds_Engines_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="[by {author}]" Type="single_dropdown1" Visible="True">
+            <Size>22014</Size>
+            <ZipFile>Sounds_Engines_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
+            <CRC>f</CRC>
+            <Timestamp>132353110299441130</Timestamp>
+            <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+            <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
+            <Author>Fedor Saveliev</Author>
+            <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
+            <Dependencies>
+              <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+            </Dependencies>
+          </Package>
+          <Package PackageName="Sounds_Engines_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="[by {author}]" Type="single_dropdown1" Visible="True">
+            <Size>8141</Size>
+            <ZipFile>Sounds_Engines_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+            <CRC>f</CRC>
+            <Timestamp>132353109714656692</Timestamp>
+            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
+            <Author>SicFunzler</Author>
+            <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
+            <UpdateComment>T10 Fix"V-12-6": \r\n{                "wwsoundPC": "V_12P",\r\n                "wwsoundNPC": "V_12P_NPC"           },\r\n\r\nUpdate  G&amp;M  V230  ( 04.03.2020 )</UpdateComment>
+            <Dependencies>
+              <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+            </Dependencies>
+          </Package>
+        </Packages>
       </Package>
-      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="[by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="[by {author}]" Type="single1" Visible="True">
         <Size>21658356</Size>
         <Version>1.2.0.1</Version>
         <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.2.0.1_2018-10-18.zip</ZipFile>
@@ -665,7 +672,7 @@
           <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Engines_HRMOD" Enabled="True" InstallGroup="4" PatchGroup="4" UID="x8q7i2oj8zh328uv" Name="HRMOD v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_HRMOD" Enabled="True" InstallGroup="4" PatchGroup="4" UID="x8q7i2oj8zh328uv" Name="HRMOD v{version} [by {author}]" Type="single1" Visible="True">
         <Size>3065</Size>
         <Version>3.00</Version>
         <ZipFile>Sounds_Engines_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
@@ -687,7 +694,7 @@
           <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Engines_AGQJ_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+      <Package PackageName="Sounds_Engines_NOTES_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="none" Visible="False">
         <Size>83692900</Size>
         <Version>1.2.0.0</Version>
         <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.2.0_2018-10-12.zip</ZipFile>
@@ -696,7 +703,7 @@
         <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
         <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
       </Package>
-      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="h1k8q4q42b3sepq8" Name="NOTES: Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
+      <Package PackageName="Sounds_Engines_NOTES_Ed76na+Apa6ecka" Enabled="False" InstallGroup="4" PatchGroup="4" UID="h1k8q4q42b3sepq8" Name="NOTES: Engines by Ed76na &amp; Apa6ecka" Type="none" Visible="False">
         <Size>21654503</Size>
         <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.1.0_2018-08-31.zip</ZipFile>
         <CRC>dfb5e70f2e91630d08e92fc01ff0d1ea</CRC>
@@ -784,12 +791,12 @@
       </Package>
     </Packages>
   </Package>
-  <Package PackageName="Sounds_Gun" Enabled="True" InstallGroup="4" PatchGroup="4" UID="1tfay7spvnqhp5nl" Name="Gun" Type="multi" Visible="True">
+  <Package PackageName="Sounds_Guns" Enabled="True" InstallGroup="4" PatchGroup="4" UID="1tfay7spvnqhp5nl" Name="Guns" Type="multi" Visible="True">
     <Dependencies>
       <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
     </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_Gun_913" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lmab5auaozc60ljx" Name="0.9.13 v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_913" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lmab5auaozc60ljx" Name="0.9.13 v{version} [by {author}]" Type="single1" Visible="True">
         <Size>2688534</Size>
         <Version>1.0</Version>
         <ZipFile>Sound_Gun_Sounds_By_Violence_1.4.1.1_2019-04-04.zip</ZipFile>
@@ -799,39 +806,46 @@
         <Author>Violence</Author>
         <Description>All sounds are inherited from the original WoT 0.9.13 client.\n\nCovered sounds: 45mm, 76mm, 100mm, 122mm, 152mm\n\nSorry, no autocannon sounds yet.</Description>
       </Package>
-      <Package PackageName="Sounds_Gun_AGQJv1FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ [by {author}]" Type="single_dropdown1" Visible="True">
-        <Size>13133</Size>
-        <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_Gun_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>f</CRC>
-        <Timestamp>132353106271010963</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
-        <Author>Fedor Saveliev</Author>
-        <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_AGQJv2SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ v{version} [by {author}] " Type="single_dropdown1" Visible="True">
-        <Size>15995</Size>
+      <Package PackageName="Sounds_Guns_AGQJ" Enabled="True" InstallGroup="4" PatchGroup="2" UID="by4pnina7sywco5o" Name="AGQJ v{version}" Type="single1" Visible="False">
+        <Size>96202544</Size>
         <Version>234</Version>
-        <ZipFile>Sounds_Gun_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <ZipFile>Sounds_Guns_AGQJ_v234_1.9.0.0_2020-04-23.zip</ZipFile>
         <CRC>f</CRC>
-        <Timestamp>132353106348541606</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
-        <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
-        <Author>SicFunzler</Author>
-        <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
+        <Timestamp>132353239074879465</Timestamp>
+        <Packages>
+          <Package PackageName="Sounds_Guns_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="[by {author}]" Type="single_dropdown1" Visible="True">
+            <Size>13133</Size>
+            <ZipFile>Sounds_Gun_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
+            <CRC>f</CRC>
+            <Timestamp>132353106271010963</Timestamp>
+            <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+            <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
+            <Author>Fedor Saveliev</Author>
+            <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
+            <Dependencies>
+              <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+            </Dependencies>
+          </Package>
+          <Package PackageName="Sounds_Guns_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="[by {author}] " Type="single_dropdown1" Visible="True">
+            <Size>15995</Size>
+            <ZipFile>Sounds_Gun_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+            <CRC>f</CRC>
+            <Timestamp>132353106348541606</Timestamp>
+            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
+            <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
+            <Author>SicFunzler</Author>
+            <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
+            <Dependencies>
+              <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
+              <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+            </Dependencies>
+          </Package>
+        </Packages>
       </Package>
-      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jlhkdjoy66n9ybu0" Name="[by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jlhkdjoy66n9ybu0" Name="[by {author}]" Type="single1" Visible="True">
         <Size>34292701</Size>
         <Version>1.8.0.0</Version>
         <ZipFile>Sounds_Gun_GO_by_Ed76na+Apa6ecka_1.8.0.0_2020-03-04.zip</ZipFile>
@@ -850,7 +864,7 @@
           <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Gun_HRMOD" Enabled="True" InstallGroup="4" PatchGroup="4" UID="spyx5dquif6dbq8a" Name="HRMOD v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_HRMOD" Enabled="True" InstallGroup="4" PatchGroup="4" UID="spyx5dquif6dbq8a" Name="HRMOD v{version} [by {author}]" Type="single1" Visible="True">
         <Size>15787</Size>
         <Version>3.00</Version>
         <ZipFile>Sounds_Gun_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
@@ -872,7 +886,7 @@
           <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Gun_ShimadaSamas" Enabled="True" InstallGroup="4" PatchGroup="4" UID="f0rixektjievbe1b" Name="[by {author}] v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_ShimadaSamas" Enabled="True" InstallGroup="4" PatchGroup="4" UID="f0rixektjievbe1b" Name="[by {author}] v{version}" Type="single1" Visible="True">
         <Size>40928630</Size>
         <Version>5.40</Version>
         <ZipFile>Sound_Mods_Gun_by_Shimada_Samas_5.40_1.9.0.1_2020-04-26.zip</ZipFile>
@@ -887,7 +901,7 @@
           <Media URL="https://youtu.be/kqOTdQ9OlIw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_Gun_StarTrekPhaser" Enabled="True" InstallGroup="4" PatchGroup="4" UID="eimp66yqukiyphuk" Name="Star Trek Phasers v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_StarTrekPhaser" Enabled="True" InstallGroup="4" PatchGroup="4" UID="eimp66yqukiyphuk" Name="Star Trek Phasers v{version} [by {author}]" Type="single1" Visible="True">
         <Size>7744194</Size>
         <Version>6.2831</Version>
         <ZipFile>Sound_Mods_Gun_Sounds_The_Illusion_Star_Trek_Weapons_2019-05-04.zip</ZipFile>
@@ -897,7 +911,7 @@
         <Description>Changes all guns to be more phasery!</Description>
         <UpdateComment>V6.2831 - Added to "Effects" volume slider\nV3.1415 Updated all sounds to be better quality</UpdateComment>
       </Package>
-      <Package PackageName="Sounds_Gun_Wrath" Enabled="True" InstallGroup="4" PatchGroup="4" UID="8x3wxao9p3ko09cy" Name="Wrath Of The Gods v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_Wrath" Enabled="True" InstallGroup="4" PatchGroup="4" UID="8x3wxao9p3ko09cy" Name="Wrath Of The Gods v{version} [by {author}]" Type="single1" Visible="True">
         <Size>3747536</Size>
         <Version>2.314</Version>
         <ZipFile>Sound_Mods_Gun_Sounds_TheIllusion_Wrath_V2.314_1.5.1.1_2019-06-24.zip</ZipFile>
@@ -911,7 +925,7 @@
           <Media URL="https://youtu.be/J3v3TZhLk4I" MediaType="Webpage" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_Gun_WWIIHWA" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Guns_WWIIHWA" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA v{version} [by {author}]" Type="single1" Visible="True">
         <Size>15210784</Size>
         <Version>4.09</Version>
         <ZipFile>Sounds_WWIIHWA_Gunsounds_v4.09_1.7.1.0_2020-01-29.zip</ZipFile>
@@ -924,7 +938,7 @@
           <Media URL="http://bigmods.relhaxmodpack.com/WoT/Medias/Pictures/Sounds_WWIIHWA_Guns_by_KT+Budyx69_Mod.png" MediaType="Picture" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_Gun_AGQJ_SoundinjektorNOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="chtydgsecrt2m65n" Name="NOTES: AGQJ Gun Sounds by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+      <Package PackageName="Sounds_Guns_NOTES_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="chtydgsecrt2m65n" Name="NOTES: AGQJ Gun Sounds by Fedor Saveliev (SoundEventInjector)" Type="none" Visible="False">
         <Size>95845585</Size>
         <Version>1502</Version>
         <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_1.5.0.2_2019-05-18.zip</ZipFile>
@@ -934,7 +948,7 @@
         <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
         <Description>Editor test: Hallo Relhax V2 - grown up from childish beta status</Description>
       </Package>
-      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="wanzliuz53grxm10" Name="NOTES: Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
+      <Package PackageName="Sounds_Guns_NOTES_Ed76na+Apa6ecka" Enabled="False" InstallGroup="4" PatchGroup="4" UID="wanzliuz53grxm10" Name="NOTES: Gun Sounds by Ed76na &amp; Apa6ecka" Type="none" Visible="False">
         <Size>34224145</Size>
         <Timestamp>131701182641902565</Timestamp>
         <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -581,7 +581,7 @@
           </Package>
         </Packages>
       </Package>
-      <Package PackageName="Sounds_CrewVoices_Chinese919" Enabled="True" InstallGroup="4" PatchGroup="4" UID="2l63akvtilnd0gm8" Name="chinese female voices from WoT ASIA v 9.19" Type="single1" Visible="True">
+      <Package PackageName="Sounds_CrewVoices_Chinese919" Enabled="True" InstallGroup="4" PatchGroup="4" UID="2l63akvtilnd0gm8" Name="Chinese female voices from WoT ASIA v 9.19" Type="single1" Visible="True">
         <Size>9273139</Size>
         <ZipFile>Sound_Crew_Sound_Chinese_9.19_By_kevin329_1.4.1.1_2019-04-04.zip</ZipFile>
         <CRC>6fb1fdb11cf24573fc1bb6e99559e6e9</CRC>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -640,202 +640,86 @@
           </Package>
         </Packages>
       </Package>
-      <Package PackageName="Sounds_CrewVoices_English" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lr70rss3bzqwwx8o" Name="English" Type="single1" Visible="True">
+      <Package PackageName="Sounds_CrewVoices_English" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lr70rss3bzqwwx8o" Name="English Crew Voices" Type="single1" Visible="True">
         <Packages>
-          <Package PackageName="Sounds_CrewVoices_English_81" Enabled="True" InstallGroup="4" PatchGroup="4" UID="kt4sv9yj72pkrbet" Name="8.1 Crew Sounds [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>5874342</Size>
-            <ZipFile>Sound_Mods_Crew_Sounds_81CrewSounds_1.5.0.3_2019-05-22.zip</ZipFile>
-            <CRC>9c3b01ac0d03f2f8d5bf37d9d8971685</CRC>
-            <Timestamp>132030347594545646</Timestamp>
-            <Author>The_Illusive_Man</Author>
-            <Description>Brings back the 8.1 crew sounds</Description>
-            <Dependencies>
-              <Dependency PackageName="Dependency_XML_loadOrder" NotFlag="False" Logic="OR" />
-              <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-            </Dependencies>
+          <Package PackageName="Sounds_CrewVoices_English_JohnTankPL" Enabled="False" InstallGroup="4" PatchGroup="4" UID="ygdf0sy4avjew8fo" Name="English Crew Sounds by JohnTankPL" Type="single1" Visible="False">
+            <Size>25743715</Size>
+            <ZipFile>Sounds_Crew_Sounds_Dzwieki_zalogi_By_JohnTankPL.zip</ZipFile>
+            <CRC>963a2d37c84339aa8cd85cf13ce91d97</CRC>
+            <Timestamp>131987322114911464</Timestamp>
+            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/603317-audio-1411-dzwieki-zalogi/</DevURL>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_AllFemale" Enabled="False" InstallGroup="4" PatchGroup="4" UID="y0g0vfqnwxezektj" Name="Elkano's All Female Voices (ElkAFV) [by {author}]" Type="single_dropdown1" Visible="False">
-            <Size>1580</Size>
-            <ZipFile>Sounds_Elkanos_All_Female_Crew_Voices_(ElkAFV).zip</ZipFile>
-            <CRC>bf50b80e62b54ffadd5a643ed577a800</CRC>
-            <DevURL>https://mods.curse.com/wot-mods/worldoftanks/269045-elkafv</DevURL>
-            <Author>Elkano</Author>
-            <Description>ElkAFV:  Very, very quiet, quiet as hell\nChange the default voice gender of all crews to female\n\nElkano: Very, very quiet, quiet as hell\nChange the default voice of all crews</Description>
-            <UpdateComment>\nElkano:\nElkASV:updated to 0.9.20.0\nElkAFV:\nv1.0 - updated to 0.9.19.0.1</UpdateComment>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_AW" Enabled="True" InstallGroup="4" PatchGroup="4" UID="e8mzndo22lra34w6" Name="Armored Warfare [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>4272027</Size>
-            <ZipFile>Sound_Mods_Crew_Sounds_AW_by_Theillusion_1.5.1.1_2019-06-28.zip</ZipFile>
-            <CRC>73726ccddb3ef861d6386f69c3f091f5</CRC>
-            <Timestamp>132009438482404233</Timestamp>
-            <Author>The_Illusive_Man</Author>
-            <Description>Changes most crew sounds to that of Armored Warfare. Includes both Male, and Female sounds.</Description>
-            <UpdateComment>V2:\r\n- Added Female Crew Sounds\r\n- Complete Rework - Added over 200 sounds</UpdateComment>
-            <Dependencies>
-              <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-            </Dependencies>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Combined" Enabled="True" InstallGroup="4" PatchGroup="4" UID="74xdn9si86x3rz7t" Name="Combined Crew Sounds (Read Description) [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>11618720</Size>
-            <Version>2020-02-27</Version>
-            <ZipFile>Sounds_Crew_Voices_The_Illusive_Man_Combined_1.7.1.2_2020-02-27.zip</ZipFile>
-            <CRC>358881f2c874af47205930bea7597ae9</CRC>
-            <Timestamp>132272849848981900</Timestamp>
-            <InternalNotes>This uses \gui\soundModes\main_sound_modes.xml. But does not patch it. This may be changed in the future.</InternalNotes>
-            <Author>The Illusion</Author>
-            <Description>This includes the following crew voice mods in one package:\r\n\r\n- Armored Warfare\r\n- Deadpool\r\n- Star Trek</Description>
-            <Medias>
-              <Media URL="http://bigmods.relhaxmodpack.com/Medias/Pictures/sound_mods/Crew Sound Mods/The Illusion/shot_043.jpg" MediaType="Picture" />
-            </Medias>
-            <Dependencies>
-              <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-            </Dependencies>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Deadpool" Enabled="True" InstallGroup="4" PatchGroup="4" UID="rxsevcu31ijs3f46" Name="Deadpool v{version} [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>4465309</Size>
-            <Version>2.1</Version>
-            <ZipFile>Sound_Mods_Crew_Sounds_Deadpool_V2_1.5.0.4_2019-06-01.zip</ZipFile>
-            <CRC>27afdc78e1781f57a9e31ec964da0750</CRC>
-            <Timestamp>131841511508320234</Timestamp>
-            <DevURL>http://forum.worldoftanks.com/index.php?/topic/587664-star-trek-sound-mod/</DevURL>
-            <Author>The_Illusive_Man</Author>
-            <Description>Basically adds Deadpool sounds to the game. Chimichangas!\n\nPlease note that it does not currently replace all sounds.</Description>
-            <UpdateComment>- Updated to 1.5 wwise project\r\n- Added 80 new sounds\r\n- Fixed event posting\r\n- Fixed audio levels (When below 30, still happens below 20ish)</UpdateComment>
-            <Dependencies>
-              <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-            </Dependencies>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_dukeNukem" Enabled="True" InstallGroup="4" PatchGroup="4" UID="svvmrvon5ek381x1" Name="Duke Nukem [by {author}]" Type="single_dropdown1" Visible="True">
+          <Package PackageName="Sounds_CrewVoices_English_dukeNukem" Enabled="True" InstallGroup="4" PatchGroup="4" UID="svvmrvon5ek381x1" Name="Duke Nukem by Silgi" Type="single1" Visible="True">
             <Size>13876468</Size>
             <Version>1.10.1</Version>
             <ZipFile>Sounds_Crew_Sounds_duke_nukem_by_Silgi_EN_1.1.0_2019-09-06.zip</ZipFile>
             <CRC>cd86686e2e77d7529cd1bceb98c87ffd</CRC>
             <Timestamp>131806675515689164</Timestamp>
             <DevURL>https://wgmods.net/1014/details</DevURL>
-            <Author>Silgi</Author>
             <Description>Mods by Silgi: https://wgmods.net/search/?owner=138375</Description>
             <UpdateComment>v1.10.1 = v1.10\nThe simple version has the audioww\voiceover.bnk included</UpdateComment>
             <Medias>
               <Media URL="https://youtu.be/BjDIlk-0ijI?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
             </Medias>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_JohnTankPL" Enabled="False" InstallGroup="4" PatchGroup="4" UID="ygdf0sy4avjew8fo" Name="English [by {author}]" Type="single_dropdown1" Visible="False">
-            <Size>25743715</Size>
-            <ZipFile>Sounds_Crew_Sounds_Dzwieki_zalogi_By_JohnTankPL.zip</ZipFile>
-            <CRC>963a2d37c84339aa8cd85cf13ce91d97</CRC>
-            <Timestamp>131987322114911464</Timestamp>
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/603317-audio-1411-dzwieki-zalogi/</DevURL>
-            <Author>JohnTankPL</Author>
+          <Package PackageName="Sounds_CrewVoices_English_DrDisrespect" Enabled="False" InstallGroup="4" PatchGroup="4" UID="5k11zvuo4bdl7d41" Name="Dr. Disrespect by SirSchmidt" Type="single1" Visible="False">
+            <Size>30034447</Size>
+            <ZipFile>Sounds_Crew_Sounds_Dr_Disrespect_2019-07-21.zip</ZipFile>
+            <CRC>00c4f15cd81500ce0bbdaac0494e3d9e</CRC>
+            <Timestamp>132082301791347159</Timestamp>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Julie" Enabled="True" InstallGroup="4" PatchGroup="4" UID="i98g7u0p37537pb1" Name="Julie Voice Pack [by {author}]" Type="single_dropdown1" Visible="True">
+          <Package PackageName="Sounds_CrewVoices_English_Julie" Enabled="True" InstallGroup="4" PatchGroup="4" UID="i98g7u0p37537pb1" Name="Julie Voice Pack by niserius" Type="single1" Visible="True">
             <Size>855212</Size>
             <ZipFile>Sounds_Julie_Voice_Pack_1.1.0.zip</ZipFile>
             <CRC>3e6f728be539ef1f2901dfc7f680dbcd</CRC>
             <Timestamp>131803112589913544</Timestamp>
             <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
-            <Author>niserius</Author>
             <Description>\nJulie:\nMust have sound crew language set to "standard"</Description>
             <UpdateComment>\nJulie:\nupdated by niserius</UpdateComment>
             <Medias>
               <Media URL="https://www.youtube.com/watch?v=J0uWJ1XKOvg?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
             </Medias>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_LeviathanEvent2017" Enabled="True" InstallGroup="4" PatchGroup="4" UID="cnpnzyq8yq7sjite" Name="Leviathan Event 2017 [by {author}]" Type="single_dropdown1" Visible="True">
+          <Package PackageName="Sounds_CrewVoices_English_LeviathanEvent2017" Enabled="True" InstallGroup="4" PatchGroup="4" UID="cnpnzyq8yq7sjite" Name="Leviathan Event 2017" Type="single1" Visible="True">
             <Size>4391124</Size>
             <ZipFile>Sounds_Crew_voices_LEVIATHAN_EVENT_2017_by_psyartax_v1.3_2019-01-12.zip</ZipFile>
             <CRC>a98526f93c4ecdac0896d1628d2af929</CRC>
             <Timestamp>131917960812089040</Timestamp>
             <DevURL>https://wgmods.net/2780/details</DevURL>
-            <Author>psyartax</Author>
             <Description>works for female crew\nDoesn’t work on Italian Tanks</Description>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_mightyJingles" Enabled="True" InstallGroup="4" PatchGroup="4" UID="019rn6wyeq3vguig" Name="The Mighty Jingles [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>19478898</Size>
-            <ZipFile>Sounds_mighty_jingles_Voice_Pack_1.1.0.zip</ZipFile>
-            <CRC>f346e22d46dd5a6952b3507ff77a83a8</CRC>
-            <Timestamp>131807564554552562</Timestamp>
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
-            <Author>niserius</Author>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Minions" Enabled="True" InstallGroup="4" PatchGroup="4" UID="isb13it8p90op0pw" Name="Minions" Type="single_dropdown1" Visible="True">
-            <Size>4435341</Size>
-            <Version>1.1.0</Version>
-            <ZipFile>Sounds_Minions_Voice_Pack_1.1.0.zip</ZipFile>
-            <CRC>3717c6875371c4371663acc18d6b19bb</CRC>
-            <Timestamp>131803112711823360</Timestamp>
-            <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12029-</DevURL>
-            <Author>Andre_V</Author>
-            <Description>Author: Mick42 and Andre_V; \nThis mod changes the standard voice acting crew sounds (screams, laughter, singing, dancing with a tambourine, etc.) minions film “Despicable Me” and “Despicable Me 2”. \n\nOld URL: http://worldof-tanks.com/8-10-minions-voicepack/</Description>
-            <UpdateComment>Updated: 2018-01-11 v0.9.21.0.3</UpdateComment>
+          <Package PackageName="Sounds_CrewVoices_English_TerrorbladeOfDota" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pcw27xw9xnzajt0e" Name="Terrorblade of Dota 2" Type="single1" Visible="True">
+            <Size>7823901</Size>
+            <ZipFile>Sounds_Crew_Voices_Terrorblade_of_Dota_1.3.0.1_2019-02-04.zip</ZipFile>
+            <CRC>d06e948e7fbdb1e8383d0496bc62df3d</CRC>
+            <Timestamp>131937175724507529</Timestamp>
+            <DevURL>https://wgmods.net/2752/details</DevURL>
+            <Description>Let´s give them hell!</Description>
             <Medias>
-              <Media URL="http://wotsite.net/images/2013/12/9/8.jpg" MediaType="Picture" />
-              <Media URL="https://youtu.be/_0M0zLdKU3U?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-              <Media URL="https://youtu.be/7wKusFTzuy4?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+              <Media URL="https://youtu.be/BurczXsbcM8" MediaType="Webpage" />
             </Medias>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_MontyPython" Enabled="True" InstallGroup="4" PatchGroup="4" UID="534muim7qd86poiw" Name="Monty Python [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>18509836</Size>
-            <Version>3</Version>
-            <ZipFile>Sounds_Monty_Python_1.1.0.1.zip</ZipFile>
-            <CRC>ce12dbd1440f08c98f20a678f2d1ac7b</CRC>
-            <Timestamp>131838649055814220</Timestamp>
-            <DevURL>https://wgmods.net/621/details</DevURL>
-            <Author>Andre_V</Author>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_MLGonlyAudio" Enabled="True" InstallGroup="4" PatchGroup="4" UID="wgko71str2thuypr" Name="MLG Mod (v1 - English sound) [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>814</Size>
-            <ZipFile>Sounds_mlg_mod_voice_sound_only_patch.zip</ZipFile>
-            <CRC>c46a3d2c3701290363a0c7115ab63e37</CRC>
+          <Package PackageName="Sounds_CrewVoices_English_MLGbase" Enabled="False" InstallGroup="4" PatchGroup="4" UID="jrd9z1mss610umir" Name="MLG Mod by Aimdrol (English sound and text)" Type="single1" Visible="True">
+            <Size>26113309</Size>
+            <ZipFile>Sounds_mlg_mod_voice_1.7.1.0_2020-01-29.zip</ZipFile>
+            <CRC>0fa8fc8fe27c70bc966f480cde9cd8b1</CRC>
+            <Timestamp>132247631589781323</Timestamp>
             <DevURL>http://forum.worldoftanks.eu/index.php?/topic/476721-</DevURL>
-            <Author>Aimdrol </Author>
-            <Description>Must have sound crew language set to "standard"\nMLG EVERYWHERE</Description>
-            <Dependencies>
-              <Dependency PackageName="Dependency_MLG_bnk" NotFlag="False" Logic="OR" />
-              <Dependency PackageName="Dependency_MLG_englishLocalization" NotFlag="False" Logic="OR" />
-              <Dependency PackageName="Dependency_CrewVoices_English_MLG" NotFlag="False" Logic="OR" />
-            </Dependencies>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_MLGvisuals" Enabled="True" InstallGroup="4" PatchGroup="4" UID="95r3f0yurzmzu9xr" Name="MLG Mod (v2 - English sound and text) [by {author}]" Type="single_dropdown1" Visible="True">
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/476721-</DevURL>
-            <Author>Aimdrol </Author>
             <Description>Must have sound crew language set to "standard"\nMLG EVERYWHERE\nAlso includes awesome visuals.</Description>
             <Dependencies>
               <Dependency PackageName="Dependency_MLG_bnk" NotFlag="False" Logic="OR" />
               <Dependency PackageName="Dependency_MLG_englishLocalization" NotFlag="False" Logic="OR" />
-              <Dependency PackageName="Dependency_CrewVoices_English_MLG" NotFlag="False" Logic="OR" />
             </Dependencies>
+            <Packages>
+              <Package PackageName="Sounds_crew_sounds_MLG_only_audio" Enabled="True" InstallGroup="4" PatchGroup="4" UID="wgko71str2thuypr" Name="audio only, no visuals" Type="single_dropdown1" Visible="True">
+                <Size>814</Size>
+                <ZipFile>Sounds_mlg_mod_voice_sound_only_patch.zip</ZipFile>
+                <CRC>c46a3d2c3701290363a0c7115ab63e37</CRC>
+              </Package>
+              <Package PackageName="Sounds_crew_sounds_MLG_audio_and_visuals" Enabled="True" InstallGroup="4" PatchGroup="4" UID="95r3f0yurzmzu9xr" Name="audio and visuals" Type="single_dropdown1" Visible="True" />
+            </Packages>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_RelhaxCensored" Enabled="True" InstallGroup="4" PatchGroup="4" UID="nc3cf7qxfuaegjbg" Name="Relhax [censored]" Type="single_dropdown1" Visible="True">
-            <Size>23035297</Size>
-            <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Censored_2019-07-21.zip</ZipFile>
-            <CRC>5d521283ea13fcac23b7a3d01fe1cc90</CRC>
-            <Timestamp>132082298431317625</Timestamp>
-            <DevURL>http://relicgaming.org/index.php?topic=697.0</DevURL>
-            <Description>Relhax:\nReplaces all crew sounds with hilarious out-of-context sound bytes from people of the RELIC gaming community</Description>
-            <Medias>
-              <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
-              <Media URL="https://www.youtube.com/v/9kCic4vXYIE?version=3&amp;autoplay=1" MediaType="Webpage" />
-            </Medias>
-            <Dependencies>
-              <Dependency PackageName="Dependency_CrewVoices_English_Relhax" NotFlag="False" Logic="OR" />
-            </Dependencies>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_RelhaxRegular" Enabled="True" InstallGroup="4" PatchGroup="4" UID="txl5n30ekb8o5qt3" Name="Relhax [regular]" Type="single_dropdown1" Visible="True">
-            <Size>26885296</Size>
-            <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Regular_2019-07-21.zip</ZipFile>
-            <CRC>a3a6d1b96750852656959710fbdc645a</CRC>
-            <Timestamp>132082298508051632</Timestamp>
-            <DevURL>http://relicgaming.org/index.php?topic=697.0</DevURL>
-            <Description>Relhax:\nReplaces all crew sounds with hilarious out-of-context sound bytes from people of the RELIC gaming community</Description>
-            <Medias>
-              <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
-              <Media URL="https://www.youtube.com/v/9kCic4vXYIE?version=3&amp;autoplay=1" MediaType="Webpage" />
-            </Medias>
-            <Dependencies>
-              <Dependency PackageName="Dependency_CrewVoices_English_Relhax" NotFlag="False" Logic="OR" />
-            </Dependencies>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_RoadRashJailbreak" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3j8b74odliop52f4" Name="Road Rash: Jailbreak" Type="single_dropdown1" Visible="True">
+          <Package PackageName="Sounds_CrewVoices_English_RoadRashJailbreak" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3j8b74odliop52f4" Name="Road Rash: Jailbreak" Type="single1" Visible="True">
             <Size>11668684</Size>
             <ZipFile>Sounds_Crew_Voices_Road_Rash_Jailbreak_1.3.0.1_2019-01-29.zip</ZipFile>
             <CRC>b6e8da25262537bb8a6a9cdf7523033b</CRC>
@@ -846,63 +730,166 @@
               <Media URL="https://youtu.be/uUScqfIlnfY" MediaType="Webpage" />
             </Medias>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Sabaton" Enabled="True" InstallGroup="4" PatchGroup="4" UID="vhigbhz9o5s6pcwv" Name="Sabaton [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>3793558</Size>
-            <ZipFile>Sounds_Sabaton_Crew_Voices_by_Andre_V_1.1.0_2018-08-31.zip</ZipFile>
-            <CRC>edad9c3775f51a1e507861b1fe08261d</CRC>
-            <Timestamp>131802423555074634</Timestamp>
-            <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12427-</DevURL>
-            <Author>Andre_V</Author>
-            <Description>Change the default voice of all crews to Sabaton Primo Victoria</Description>
-            <UpdateComment>Updated 1.10 2018-08-31</UpdateComment>
+          <Package PackageName="Sounds_CrewVoices_English_Relhax" Enabled="True" InstallGroup="4" PatchGroup="4" UID="g8fqf3ueleg65em4" Name="Relhax" Type="single1" Visible="True">
+            <Size>1127</Size>
+            <Version>24</Version>
+            <ZipFile>Sounds_Crew_Sounds_Relhax_Base_2019-08-03.zip</ZipFile>
+            <CRC>833c22c8e5824ec90bacfe5daa96e1e5</CRC>
+            <Timestamp>132093315025806866</Timestamp>
+            <DevURL>http://relicgaming.org/index.php?topic=697.0</DevURL>
+            <Description>Relhax:\nReplaces all crew sounds with hilarious out-of-context sound bytes from people of the RELIC gaming community</Description>
             <Medias>
-              <Media URL="https://youtu.be/iT8MCiY44DA?version=3&amp;autoplay=1" MediaType="Webpage" />
+              <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
+              <Media URL="https://www.youtube.com/v/9kCic4vXYIE?version=3&amp;autoplay=1" MediaType="Webpage" />
             </Medias>
+            <Packages>
+              <Package PackageName="Sounds_CrewVoices_English_Relhax_Regular" Enabled="True" InstallGroup="4" PatchGroup="4" UID="txl5n30ekb8o5qt3" Name="standard" Type="single_dropdown1" Visible="True">
+                <Size>26885296</Size>
+                <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Regular_2019-07-21.zip</ZipFile>
+                <CRC>a3a6d1b96750852656959710fbdc645a</CRC>
+                <Timestamp>132082298508051632</Timestamp>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_Relhax_Censored" Enabled="True" InstallGroup="4" PatchGroup="4" UID="nc3cf7qxfuaegjbg" Name="censored" Type="single_dropdown1" Visible="True">
+                <Size>23035297</Size>
+                <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Censored_2019-07-21.zip</ZipFile>
+                <CRC>5d521283ea13fcac23b7a3d01fe1cc90</CRC>
+                <Timestamp>132082298431317625</Timestamp>
+              </Package>
+            </Packages>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_StarTrek" Enabled="True" InstallGroup="4" PatchGroup="4" UID="4mzt3b041ec93rb6" Name="Star Trek [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>2594110</Size>
-            <Version>v6.1</Version>
-            <ZipFile>Sound_Mods_Crew_Sounds_Star_Trek_by_The_Illusive_Man_v6.1_2019-10-08.zip</ZipFile>
-            <CRC>acbcfc19722d03a101fe1c4e497ff3ab</CRC>
-            <Timestamp>132150224087250086</Timestamp>
+          <Package PackageName="Sounds_CrewVoices_English_mightyJingles" Enabled="True" InstallGroup="4" PatchGroup="4" UID="019rn6wyeq3vguig" Name="The Mighty Jingles Voice Pack revived by niserius" Type="single1" Visible="True">
+            <Size>19478898</Size>
+            <ZipFile>Sounds_mighty_jingles_Voice_Pack_1.1.0.zip</ZipFile>
+            <CRC>f346e22d46dd5a6952b3507ff77a83a8</CRC>
+            <Timestamp>131807564554552562</Timestamp>
+            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
+          </Package>
+          <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan" Enabled="True" InstallGroup="4" PatchGroup="4" UID="ufryfamh994lrn0t" Name="English Crew Voices by The_Illusive_Man" Type="single1" Visible="True">
+            <Version>2018-10-02</Version>
+            <Timestamp>131931517940589771</Timestamp>
             <DevURL>http://forum.worldoftanks.com/index.php?/topic/587664-star-trek-sound-mod/</DevURL>
-            <Author>The_Illusive_Man</Author>
-            <Description>Currently has:\n- Scotty\n- Sulu\n- Chekov\n- Bashir\n- The Doctor\n- Generic Klingons\n- Sela\n-Quark\n-Cooper\n-Q\n\nhttps://wgmods.net/2246/</Description>
-            <UpdateComment>2019-01-05_v6:\nAdded:\nBvat_02 [vo_vehile_destroyed/male]\nBvat_03 [vo_vehile_destroyed/male]\nCooper_008 [vo_armor_not_pierced_by_player/male]\nCooper_007 [vo_dp_player_joined_platoon, vo_dp_player_joined]\nCooper_006 [vo_target_captured]\nCooper_10 [vo_dp_assistance_been_requested]\nCooper_11 [vo_dp_player_joined_platoon, vo_dp_player_joined]\nCooper_013 [vo_dp_left_platoon]\nQuark_162 [vo_enemy_fire_started_by_player]\n\nRemoved:\nScotty_27 [Not relevent to WOT]\nHolo_Leeta_Dabo3 from vo_enemy_hp_damaged_by_explosion_at_direct_hit_by_player/male [Its only supposed to be played when a female crew is used] \nRemoved extra sound files\n\nModified:\nReduced Q Death sound [Too loud]\nAdded some Spock sounds to events properly [wherent playing]</UpdateComment>
-            <Medias>
-              <Media URL="https://youtu.be/DqgGGayokfM" MediaType="Webpage" />
-            </Medias>
             <Dependencies>
               <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
             </Dependencies>
+            <Packages>
+              <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan_Combined" Enabled="True" InstallGroup="4" PatchGroup="4" UID="74xdn9si86x3rz7t" Name="Combined Crew Sounds (Read Description)" Type="single_dropdown1" Visible="True">
+                <Size>11618720</Size>
+                <Version>2020-02-27</Version>
+                <ZipFile>Sounds_Crew_Voices_The_Illusive_Man_Combined_1.7.1.2_2020-02-27.zip</ZipFile>
+                <CRC>358881f2c874af47205930bea7597ae9</CRC>
+                <Timestamp>132272849848981900</Timestamp>
+                <InternalNotes>This uses \gui\soundModes\main_sound_modes.xml. But does not patch it. This may be changed in the future.</InternalNotes>
+                <Author>The Illusion</Author>
+                <Description>This includes the following crew voice mods in one package:\r\n\r\n- Armored Warfare\r\n- Deadpool\r\n- Star Trek</Description>
+                <Medias>
+                  <Media URL="http://bigmods.relhaxmodpack.com/Medias/Pictures/sound_mods/Crew Sound Mods/The Illusion/shot_043.jpg" MediaType="Picture" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan_81" Enabled="True" InstallGroup="4" PatchGroup="4" UID="kt4sv9yj72pkrbet" Name="8.1 Crew Sounds" Type="single_dropdown1" Visible="True">
+                <Size>5874342</Size>
+                <ZipFile>Sound_Mods_Crew_Sounds_81CrewSounds_1.5.0.3_2019-05-22.zip</ZipFile>
+                <CRC>9c3b01ac0d03f2f8d5bf37d9d8971685</CRC>
+                <Timestamp>132030347594545646</Timestamp>
+                <Description>Brings back the 8.1 crew sounds</Description>
+                <Dependencies>
+                  <Dependency PackageName="Dependency_XML_loadOrder" NotFlag="False" Logic="OR" />
+                </Dependencies>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan_AW" Enabled="True" InstallGroup="4" PatchGroup="4" UID="e8mzndo22lra34w6" Name="Armored Warfare" Type="single_dropdown1" Visible="True">
+                <Size>4272027</Size>
+                <ZipFile>Sound_Mods_Crew_Sounds_AW_by_Theillusion_1.5.1.1_2019-06-28.zip</ZipFile>
+                <CRC>73726ccddb3ef861d6386f69c3f091f5</CRC>
+                <Timestamp>132009438482404233</Timestamp>
+                <Description>Changes most crew sounds to that of Armored Warfare. Includes both Male, and Female sounds.</Description>
+                <UpdateComment>V2:\r\n- Added Female Crew Sounds\r\n- Complete Rework - Added over 200 sounds</UpdateComment>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan_Deadpool" Enabled="True" InstallGroup="4" PatchGroup="4" UID="rxsevcu31ijs3f46" Name="Deadpool v{version}" Type="single_dropdown1" Visible="True">
+                <Size>4465309</Size>
+                <Version>2.1</Version>
+                <ZipFile>Sound_Mods_Crew_Sounds_Deadpool_V2_1.5.0.4_2019-06-01.zip</ZipFile>
+                <CRC>27afdc78e1781f57a9e31ec964da0750</CRC>
+                <Timestamp>131841511508320234</Timestamp>
+                <DevURL>http://forum.worldoftanks.com/index.php?/topic/587664-star-trek-sound-mod/</DevURL>
+                <Description>Basically adds Deadpool sounds to the game. Chimichangas!\n\nPlease note that it does not currently replace all sounds.</Description>
+                <UpdateComment>- Updated to 1.5 wwise project\r\n- Added 80 new sounds\r\n- Fixed event posting\r\n- Fixed audio levels (When below 30, still happens below 20ish)</UpdateComment>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan_StarTrek" Enabled="True" InstallGroup="4" PatchGroup="4" UID="4mzt3b041ec93rb6" Name="Star Trek" Type="single_dropdown1" Visible="True">
+                <Size>2594110</Size>
+                <Version>v6.1</Version>
+                <ZipFile>Sound_Mods_Crew_Sounds_Star_Trek_by_The_Illusive_Man_v6.1_2019-10-08.zip</ZipFile>
+                <CRC>acbcfc19722d03a101fe1c4e497ff3ab</CRC>
+                <Timestamp>132150224087250086</Timestamp>
+                <DevURL>http://forum.worldoftanks.com/index.php?/topic/587664-star-trek-sound-mod/</DevURL>
+                <Description>Currently has:\n- Scotty\n- Sulu\n- Chekov\n- Bashir\n- The Doctor\n- Generic Klingons\n- Sela\n-Quark\n-Cooper\n-Q\n\nhttps://wgmods.net/2246/</Description>
+                <UpdateComment>2019-01-05_v6:\nAdded:\nBvat_02 [vo_vehile_destroyed/male]\nBvat_03 [vo_vehile_destroyed/male]\nCooper_008 [vo_armor_not_pierced_by_player/male]\nCooper_007 [vo_dp_player_joined_platoon, vo_dp_player_joined]\nCooper_006 [vo_target_captured]\nCooper_10 [vo_dp_assistance_been_requested]\nCooper_11 [vo_dp_player_joined_platoon, vo_dp_player_joined]\nCooper_013 [vo_dp_left_platoon]\nQuark_162 [vo_enemy_fire_started_by_player]\n\nRemoved:\nScotty_27 [Not relevent to WOT]\nHolo_Leeta_Dabo3 from vo_enemy_hp_damaged_by_explosion_at_direct_hit_by_player/male [Its only supposed to be played when a female crew is used] \nRemoved extra sound files\n\nModified:\nReduced Q Death sound [Too loud]\nAdded some Spock sounds to events properly [wherent playing]</UpdateComment>
+                <Medias>
+                  <Media URL="https://youtu.be/DqgGGayokfM" MediaType="Webpage" />
+                </Medias>
+              </Package>
+            </Packages>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_SteelFoxes" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pwzo2lpsjpuv05e8" Name="Steel Foxes (with Strategic Music) [by {author}]" Type="single_dropdown1" Visible="True">
-            <Size>24761023</Size>
-            <ZipFile>Sounds_crew_sounds_Steel_Foxes_by_Strategic_Music+Andre_V_english_1.1.0_2018-08-31.zip</ZipFile>
-            <CRC>13f6d2ab5f05ab7620acf8788f9e7fcc</CRC>
-            <Timestamp>131803109527255587</Timestamp>
-            <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/10241-</DevURL>
-            <Author>Andre_V</Author>
-            <Description>Steel Foxes with Strategic Music &amp; Andre_V\nNote for youtube: Just wait ca. 20 seconds (russian language over)\n-provides alternative voice reactions from the tank crew. \n-More than 750 phrases for 45 different in-game situations.\n-gives you a new gaming experience\n-new emotions, atmosphere and some humor\n\nThe mod team:\nDmitry Kuzmenko – original idea, voice direction, script writing\nWill Bucknum – script writing, voice direction\nAaron Baca – script writing\nTechnical director – Serge Eybog\nSound design – Andrew Burmistrov, Stas Polesko, Petr Yakyamsev\nDouglas Pullar – commander\nJohn Bell – additional voice-over</Description>
-            <UpdateComment>Updated 1.10 2018-08-31\n\n\nRemoved ekspont_load.wotmod &amp; LobbyApi.wotmod</UpdateComment>
-            <Medias>
-              <Media URL="http://wotsite.net/images/2013/11/25/13.jpg" MediaType="Picture" />
-              <Media URL="https://youtu.be/565ek6lrqbo?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-            </Medias>
-            <Dependencies>
-              <Dependency PackageName="Dependency_XML_audioMods" NotFlag="False" Logic="OR" />
-            </Dependencies>
+          <Package PackageName="Sounds_CrewVoices_English_AllFemale" Enabled="False" InstallGroup="4" PatchGroup="4" UID="y0g0vfqnwxezektj" Name="Elkano's All Female Voices (ElkAFV)" Type="single1" Visible="False">
+            <Size>1580</Size>
+            <ZipFile>Sounds_Elkanos_All_Female_Crew_Voices_(ElkAFV).zip</ZipFile>
+            <CRC>bf50b80e62b54ffadd5a643ed577a800</CRC>
+            <DevURL>https://mods.curse.com/wot-mods/worldoftanks/269045-elkafv</DevURL>
+            <Description>ElkAFV:  Very, very quiet, quiet as hell\nChange the default voice gender of all crews to female\n\nElkano: Very, very quiet, quiet as hell\nChange the default voice of all crews</Description>
+            <UpdateComment>\nElkano:\nElkASV:updated to 0.9.20.0\nElkAFV:\nv1.0 - updated to 0.9.19.0.1</UpdateComment>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_TerrorbladeOfDota" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pcw27xw9xnzajt0e" Name="Terrorblade of Dota 2" Type="single_dropdown1" Visible="True">
-            <Size>7823901</Size>
-            <ZipFile>Sounds_Crew_Voices_Terrorblade_of_Dota_1.3.0.1_2019-02-04.zip</ZipFile>
-            <CRC>d06e948e7fbdb1e8383d0496bc62df3d</CRC>
-            <Timestamp>131937175724507529</Timestamp>
-            <DevURL>https://wgmods.net/2752/details</DevURL>
-            <Description>Let´s give them hell!</Description>
-            <Medias>
-              <Media URL="https://youtu.be/BurczXsbcM8" MediaType="Webpage" />
-            </Medias>
+          <Package PackageName="Sounds_CrewVoices_English_AndreV" Enabled="True" InstallGroup="4" PatchGroup="4" UID="bpnf3fwovu6hev0j" Name="English Crew Voices by Andre_V" Type="single1" Visible="True">
+            <Packages>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_MontyPython" Enabled="True" InstallGroup="4" PatchGroup="4" UID="534muim7qd86poiw" Name="Monty Python" Type="single_dropdown1" Visible="True">
+                <Size>18509836</Size>
+                <Version>3</Version>
+                <ZipFile>Sounds_Monty_Python_1.1.0.1.zip</ZipFile>
+                <CRC>ce12dbd1440f08c98f20a678f2d1ac7b</CRC>
+                <Timestamp>131838649055814220</Timestamp>
+                <DevURL>https://wgmods.net/621/details</DevURL>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_Minions" Enabled="True" InstallGroup="4" PatchGroup="4" UID="isb13it8p90op0pw" Name="Minions Voice Pack" Type="single_dropdown1" Visible="True">
+                <Size>4435341</Size>
+                <Version>1.1.0</Version>
+                <ZipFile>Sounds_Minions_Voice_Pack_1.1.0.zip</ZipFile>
+                <CRC>3717c6875371c4371663acc18d6b19bb</CRC>
+                <Timestamp>131803112711823360</Timestamp>
+                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12029-</DevURL>
+                <Description>Author: Mick42 and Andre_V; \nThis mod changes the standard voice acting crew sounds (screams, laughter, singing, dancing with a tambourine, etc.) minions film “Despicable Me” and “Despicable Me 2”. \n\nOld URL: http://worldof-tanks.com/8-10-minions-voicepack/</Description>
+                <UpdateComment>Updated: 2018-01-11 v0.9.21.0.3</UpdateComment>
+                <Medias>
+                  <Media URL="http://wotsite.net/images/2013/12/9/8.jpg" MediaType="Picture" />
+                  <Media URL="https://youtu.be/_0M0zLdKU3U?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                  <Media URL="https://youtu.be/7wKusFTzuy4?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_Sabaton" Enabled="True" InstallGroup="4" PatchGroup="4" UID="vhigbhz9o5s6pcwv" Name="Sabaton Voices" Type="single_dropdown1" Visible="True">
+                <Size>3793558</Size>
+                <ZipFile>Sounds_Sabaton_Crew_Voices_by_Andre_V_1.1.0_2018-08-31.zip</ZipFile>
+                <CRC>edad9c3775f51a1e507861b1fe08261d</CRC>
+                <Timestamp>131802423555074634</Timestamp>
+                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12427-</DevURL>
+                <Description>Change the default voice of all crews to Sabaton Primo Victoria</Description>
+                <UpdateComment>Updated 1.10 2018-08-31</UpdateComment>
+                <Medias>
+                  <Media URL="https://youtu.be/iT8MCiY44DA?version=3&amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_SteelFoxes" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pwzo2lpsjpuv05e8" Name="Steel Foxes with Strategic Music" Type="single_dropdown1" Visible="True">
+                <Size>24761023</Size>
+                <ZipFile>Sounds_crew_sounds_Steel_Foxes_by_Strategic_Music+Andre_V_english_1.1.0_2018-08-31.zip</ZipFile>
+                <CRC>13f6d2ab5f05ab7620acf8788f9e7fcc</CRC>
+                <Timestamp>131803109527255587</Timestamp>
+                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/10241-</DevURL>
+                <Description>Steel Foxes with Strategic Music &amp; Andre_V\nNote for youtube: Just wait ca. 20 seconds (russian language over)\n-provides alternative voice reactions from the tank crew. \n-More than 750 phrases for 45 different in-game situations.\n-gives you a new gaming experience\n-new emotions, atmosphere and some humor\n\nThe mod team:\nDmitry Kuzmenko – original idea, voice direction, script writing\nWill Bucknum – script writing, voice direction\nAaron Baca – script writing\nTechnical director – Serge Eybog\nSound design – Andrew Burmistrov, Stas Polesko, Petr Yakyamsev\nDouglas Pullar – commander\nJohn Bell – additional voice-over</Description>
+                <UpdateComment>Updated 1.10 2018-08-31\n\n\nRemoved ekspont_load.wotmod &amp; LobbyApi.wotmod</UpdateComment>
+                <Medias>
+                  <Media URL="http://wotsite.net/images/2013/11/25/13.jpg" MediaType="Picture" />
+                  <Media URL="https://youtu.be/565ek6lrqbo?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+                <Dependencies>
+                  <Dependency PackageName="Dependency_XML_audioMods" NotFlag="False" Logic="OR" />
+                </Dependencies>
+              </Package>
+            </Packages>
           </Package>
         </Packages>
       </Package>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -614,13 +614,30 @@
       <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
     </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_Engines_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ Engines by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_AGQJv1FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ [by {author}]" Type="single_dropdown1" Visible="True">
+        <Size>22014</Size>
+        <Version>1.9.0.0</Version>
+        <ZipFile>Sounds_Engines_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353110299441130</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
+        <Author>Fedor Saveliev</Author>
+        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
+        <Dependencies>
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Engines_AGQJv2SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ v{version} [by {author}]" Type="single_dropdown1" Visible="True">
         <Size>8141</Size>
         <Version>234</Version>
         <ZipFile>Sounds_Engines_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
         <CRC>f</CRC>
         <Timestamp>132353109714656692</Timestamp>
         <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
+        <Author>SicFunzler</Author>
         <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
         <UpdateComment>T10 Fix"V-12-6": \r\n{                "wwsoundPC": "V_12P",\r\n                "wwsoundNPC": "V_12P_NPC"           },\r\n\r\nUpdate  G&amp;M  V230  ( 04.03.2020 )</UpdateComment>
         <Dependencies>
@@ -629,22 +646,7 @@
           <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Engines_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ Engines by Fedor Saveliev" Type="single_dropdown1" Visible="True">
-        <Size>22014</Size>
-        <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_Engines_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>f</CRC>
-        <Timestamp>132353110299441130</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
-        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <Dependencies>
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="[by {author}]" Type="single_dropdown1" Visible="True">
         <Size>21658356</Size>
         <Version>1.2.0.1</Version>
         <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.2.0.1_2018-10-18.zip</ZipFile>
@@ -652,6 +654,7 @@
         <Timestamp>131843677273540576</Timestamp>
         <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
         <InternalNotes> (no original files by WG as template)</InternalNotes>
+        <Author>Ed76na &amp; Apa6ecka</Author>
         <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
         <UpdateComment>1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
         <Medias>
@@ -662,7 +665,7 @@
           <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Engines_HRMOD_GnomeFather_Zorgane" Enabled="True" InstallGroup="4" PatchGroup="4" UID="x8q7i2oj8zh328uv" Name="GnomeFather’s HRMOD Engines Sounds (reworked by Zorgane)  v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_HRMOD" Enabled="True" InstallGroup="4" PatchGroup="4" UID="x8q7i2oj8zh328uv" Name="HRMOD v{version} [by {author}]" Type="single_dropdown1" Visible="True">
         <Size>3065</Size>
         <Version>3.00</Version>
         <ZipFile>Sounds_Engines_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
@@ -670,6 +673,7 @@
         <Timestamp>132325073809233568</Timestamp>
         <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
         <InternalNotes>own soundbanks by Zorgane:\naudioww\Zorg_Guns_Engines.bnk\naudioww\Zorg_Guns_Engines.pck\n\nmoded scripts\nscripts\item_defs\vehicles\r\n\r\nhttps://www.mediafire.com/folder/dh5bf45314xfo/Gnomefather's_HRMOD</InternalNotes>
+        <Author>GnomeFather / Zorgane</Author>
         <Description>Dont forget : I (Zorgane) need reviews ! - use devolper website to do this please\n\nNote : Scripts for remodels are unavailable for the moment.</Description>
         <UpdateComment>V. 2.18 Added FV/T95 custom sounds\r\nFixed german HL234 engine\r\n\r\nV. 2.16 Fixed scripts for xmas style\r\nFixed Panther turbo engine sound\r\nFixed missing french engine sounds\r\n\r\nV.2.15: Added engine sounds for some american tanks\r\nV.2.14: Added support for Super Hellcat\r\n\r\nV. 2.10 Patchnote Compatibility with 1.6.0.2\r\nFixed leopard engine sound\r\nFixed T-116 gun sound\r\nAdded 64bit memory profile\r\n</UpdateComment>
         <Medias>
@@ -681,20 +685,6 @@
           <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
           <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
           <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Engines_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="4ceui5k32fbaedj8" Name="AGQJ Engines by Fedor Saveliev  v{version}" Type="single_dropdown1" Visible="False">
-        <Size>83692297</Size>
-        <Version>1.5.0.2</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.2_2019-05-15.zip</ZipFile>
-        <CRC>704f4f3656a7356f17c0f1f44a009ef9</CRC>
-        <Timestamp>131940420589802487</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>direct link:Engines  (no SoundEventInjector)\nhttps://yadi.sk/d/mqjb17bGynH6V\n\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
       <Package PackageName="Sounds_Engines_AGQJ_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
@@ -799,52 +789,68 @@
       <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
     </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_Gun_Star_Trek_Phaser" Enabled="True" InstallGroup="4" PatchGroup="4" UID="eimp66yqukiyphuk" Name="Star Trek Phasers by The Illusion v{version}" Type="single_dropdown1" Visible="True">
-        <Size>7744194</Size>
-        <Version>6.2831</Version>
-        <ZipFile>Sound_Mods_Gun_Sounds_The_Illusion_Star_Trek_Weapons_2019-05-04.zip</ZipFile>
-        <CRC>f588548e2b9dac3f8138cedd7c3607d5</CRC>
-        <DevURL>http://forum.worldoftanks.com/index.php?/topic/602970-1412-phaser-gun-sounds/</DevURL>
-        <Description>Changes all guns to be more phasery!</Description>
-        <UpdateComment>V6.2831 - Added to "Effects" volume slider\nV3.1415 Updated all sounds to be better quality</UpdateComment>
-      </Package>
-      <Package PackageName="Sounds_Gun_Wrath" Enabled="True" InstallGroup="4" PatchGroup="4" UID="8x3wxao9p3ko09cy" Name="Wrath Of The Gods by The Illusion v{version}" Type="single_dropdown1" Visible="True">
-        <Size>3747536</Size>
-        <Version>2.314</Version>
-        <ZipFile>Sound_Mods_Gun_Sounds_TheIllusion_Wrath_V2.314_1.5.1.1_2019-06-24.zip</ZipFile>
-        <CRC>b24279ceec70ddd7b0980d1876250489</CRC>
-        <Timestamp>132024199381905502</Timestamp>
-        <DevURL>http://forum.worldoftanks.com/index.php?/topic/604225-1501-wrath-of-the-gods-gun-sound-mod</DevURL>
-        <Description>This will make guns sound real. And scary....</Description>
-        <UpdateComment>V2.0 - Changed "NPC" Sounds to sound different, Changed 139mm+ guns sounds (Now will make you jump the first time....)</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/J3v3TZhLk4I" MediaType="Webpage" />
-        </Medias>
-      </Package>
-      <Package PackageName="Sounds_Gun_9.13" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lmab5auaozc60ljx" Name="_Violence_'s 0.9.13 Gun Sounds v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_913" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lmab5auaozc60ljx" Name="0.9.13 v{version} [by {author}]" Type="single_dropdown1" Visible="True">
         <Size>2688534</Size>
         <Version>1.0</Version>
         <ZipFile>Sound_Gun_Sounds_By_Violence_1.4.1.1_2019-04-04.zip</ZipFile>
         <CRC>92caf0d676d0f3e9f7e352d51da8157e</CRC>
         <Timestamp>131988818715738838</Timestamp>
         <DevURL>https://wgmods.net/3170/details</DevURL>
+        <Author>Violence</Author>
         <Description>All sounds are inherited from the original WoT 0.9.13 client.\n\nCovered sounds: 45mm, 76mm, 100mm, 122mm, 152mm\n\nSorry, no autocannon sounds yet.</Description>
       </Package>
-      <Package PackageName="Sounds_Gun_by_Shimada_Samas" Enabled="True" InstallGroup="4" PatchGroup="4" UID="f0rixektjievbe1b" Name="Gun Sounds by Shimada Samas" Type="single_dropdown1" Visible="True">
-        <Size>40928630</Size>
-        <Version>5.40</Version>
-        <ZipFile>Sound_Mods_Gun_by_Shimada_Samas_5.40_1.9.0.1_2020-04-26.zip</ZipFile>
-        <CRC>8a90413f14a768289cfcb9887c4977c6</CRC>
-        <Timestamp>132323646945848449</Timestamp>
-        <DevURL>https://wgmods.net/673/details</DevURL>
-        <Description>Gun Sounds by Shimada Samas /  _Shimada_Arisu_ \nI use gun sound from many source such as\n- Gnomefather\n- Battlefield\n- WarThunder\nand more.</Description>
-        <UpdateComment>Version 5.3.3 (2020-03-16)\r\n- Update for 1.8.0.1\r\n\r\nVersion 5.3.2 (2020-03-14)\r\n- Update for 1.8.0.0\r\nVersion 5.3.0\r\n- Update for 1.7.1.2 - Add gun sounds for double gun tanks\r\nVersion 5.20 (2020-01-13)\r\n- Update for 1.7.0.2 \r\n- Fix a 3D style skin bug for Jg.Pz.E100 and AMX 13 105 - Update Jg.Pz.E100 and AMX 13 105 script files</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/Pe5njjXegUM?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/kqOTdQ9OlIw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
+      <Package PackageName="Sounds_Gun_AGQJv1FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ [by {author}]" Type="single_dropdown1" Visible="True">
+        <Size>13133</Size>
+        <Version>1.9.0.0</Version>
+        <ZipFile>Sounds_Gun_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353106271010963</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
+        <Author>Fedor Saveliev</Author>
+        <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Gun_HRMOD_GnomeFather_Zorgane" Enabled="True" InstallGroup="4" PatchGroup="4" UID="spyx5dquif6dbq8a" Name="GnomeFather’s HRMOD Gun Sounds (reworked by Zorgane)  v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_AGQJv2SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ v{version} [by {author}] " Type="single_dropdown1" Visible="True">
+        <Size>15995</Size>
+        <Version>234</Version>
+        <ZipFile>Sounds_Gun_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353106348541606</Timestamp>
+        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
+        <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
+        <Author>SicFunzler</Author>
+        <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jlhkdjoy66n9ybu0" Name="[by {author}]" Type="single_dropdown1" Visible="True">
+        <Size>34292701</Size>
+        <Version>1.8.0.0</Version>
+        <ZipFile>Sounds_Gun_GO_by_Ed76na+Apa6ecka_1.8.0.0_2020-03-04.zip</ZipFile>
+        <CRC>1b23db178c16b8eba059cd454b53c146</CRC>
+        <Timestamp>132278011144054309</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
+        <InternalNotes> (no original files by WG as template)</InternalNotes>
+        <Author>Ed76na &amp; Apa6ecka</Author>
+        <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
+        <UpdateComment>2019-04-16: added HWK30, TS-5\n1412=1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
+        <Medias>
+          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Gun_HRMOD" Enabled="True" InstallGroup="4" PatchGroup="4" UID="spyx5dquif6dbq8a" Name="HRMOD v{version} [by {author}]" Type="single_dropdown1" Visible="True">
         <Size>15787</Size>
         <Version>3.00</Version>
         <ZipFile>Sounds_Gun_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
@@ -852,6 +858,7 @@
         <Timestamp>132325074171114003</Timestamp>
         <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
         <InternalNotes>These are now wotmods for conflicting reasons.\r\n\r\nown soundbanks by Zorgane:\naudioww\Zorg_Guns_Engines.bnk\naudioww\Zorg_Guns_Engines.pck\n\nmoded scripts\nscripts\item_defs\vehicles\r\n\r\nhttps://www.mediafire.com/folder/dh5bf45314xfo/Gnomefather's_HRMOD</InternalNotes>
+        <Author>GnomeFather / Zorgane</Author>
         <Description>This mod alters the sounds via the tanks xml's. This makes the mod break every patch. Expect some time for updates. Use Wrath of the Gods gun sounds, or Shimada if you want something that doesnt break every patch.\r\n\r\nDont forget : I (Zorgane) need reviews ! - use devolper website to do this please\n\n</Description>
         <UpdateComment>V. 2.18 Added FV/T95 custom sounds\r\nFixed german HL234 engine\r\n\r\nV. 2.16 Fixed scripts for xmas style\r\nFixed Panther turbo engine sound\r\nFixed missing french engine sounds\r\n\r\nV.2.15: Added engine sounds for some american tanks\r\nV.2.14: Added support for Super Hellcat\r\n\r\nV. 2.10 Patchnote Compatibility with 1.6.0.2\r\nFixed leopard engine sound\r\nFixed T-116 gun sound\r\nAdded 64bit memory profile</UpdateComment>
         <Medias>
@@ -865,101 +872,46 @@
           <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Gun_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ Guns by Fedor Saveliev" Type="single_dropdown1" Visible="True">
-        <Size>13133</Size>
-        <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_Gun_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>f</CRC>
-        <Timestamp>132353106271010963</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
-        <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ Guns by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
-        <Size>15995</Size>
-        <Version>234</Version>
-        <ZipFile>Sounds_Gun_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>f</CRC>
-        <Timestamp>132353106348541606</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
-        <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
-        <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_AGQJ_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="chtydgsecrt2m65n" Name="NOTES: AGQJ Gun Sounds by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
-        <Size>95845585</Size>
-        <Version>1502</Version>
-        <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_1.5.0.2_2019-05-18.zip</ZipFile>
-        <CRC>8ac233a3e08255f8865e948239456cbb</CRC>
-        <Timestamp>132207969933092634</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
-        <Description>Editor test: Hallo Relhax V2 - grown up from childish beta status</Description>
-      </Package>
-      <Package PackageName="Sounds_Gun_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="p6zdlfyfbnlkmicn" Name="AGQJ Gun Sounds by Fedor Saveliev v{version} (SoundEventInjector)" Type="single_dropdown1" Visible="False">
-        <Size>95868116</Size>
-        <Version>1.5.0.1</Version>
-        <ZipFile>Sounds_AGQJ_Gun_Sounds_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.1_2019-05-14.zip</ZipFile>
-        <CRC>2974ae69a73c8aa52f85a69ce016f6ab</CRC>
-        <Timestamp>131838144585727822</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>direct link :Gun_sounds (no SoundEventInjector)\nhttps://yadi.sk/d/GNoG0AI5sRcaq\n\ndirect link :Gun_sounds (SoundEventInjector)\nhttps://yadi.sk/d/2uTYjByN3TamTd\r\n\r\nmaybe confict with WWIIHWA</Description>
+      <Package PackageName="Sounds_Gun_ShimadaSamas" Enabled="True" InstallGroup="4" PatchGroup="4" UID="f0rixektjievbe1b" Name="[by {author}] v{version}" Type="single_dropdown1" Visible="True">
+        <Size>40928630</Size>
+        <Version>5.40</Version>
+        <ZipFile>Sound_Mods_Gun_by_Shimada_Samas_5.40_1.9.0.1_2020-04-26.zip</ZipFile>
+        <CRC>8a90413f14a768289cfcb9887c4977c6</CRC>
+        <Timestamp>132323646945848449</Timestamp>
+        <DevURL>https://wgmods.net/673/details</DevURL>
+        <Author>Shimada Samas</Author>
+        <Description>Gun Sounds by Shimada Samas /  _Shimada_Arisu_ \nI use gun sound from many source such as\n- Gnomefather\n- Battlefield\n- WarThunder\nand more.</Description>
+        <UpdateComment>Version 5.3.3 (2020-03-16)\r\n- Update for 1.8.0.1\r\n\r\nVersion 5.3.2 (2020-03-14)\r\n- Update for 1.8.0.0\r\nVersion 5.3.0\r\n- Update for 1.7.1.2 - Add gun sounds for double gun tanks\r\nVersion 5.20 (2020-01-13)\r\n- Update for 1.7.0.2 \r\n- Fix a 3D style skin bug for Jg.Pz.E100 and AMX 13 105 - Update Jg.Pz.E100 and AMX 13 105 script files</UpdateComment>
         <Medias>
-          <Media URL="https://youtu.be/CUs8Z42fAK0?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/XN8A0MRqw0E?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/aS_Y26uJ0SA?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/l8Kd4KuvZFg?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/5bKlYtpVTuI?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/b9Uy9Qs7kGA?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/P9ISUHoYKMY?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/JpUQhbF2Tc8?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/EiNfm2AmBQY?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/5EtBFvWcNQk?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jlhkdjoy66n9ybu0" Name="Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
-        <Size>34292701</Size>
-        <Version>1.8.0.0</Version>
-        <ZipFile>Sounds_Gun_GO_by_Ed76na+Apa6ecka_1.8.0.0_2020-03-04.zip</ZipFile>
-        <CRC>1b23db178c16b8eba059cd454b53c146</CRC>
-        <Timestamp>132278011144054309</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
-        <UpdateComment>2019-04-16: added HWK30, TS-5\n1412=1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="wanzliuz53grxm10" Name="NOTES: Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
-        <Size>34224145</Size>
-        <Timestamp>131701182641902565</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>
-        <InternalNotes>Dont use this version(PYmods_BanksLoader) with WWIIHWA: \n- Sound Event Injector is incompatible with WWIIHWA\n- "WoT-Circle": Restart -&gt; Crash -&gt; Restart -&gt; Crash....)\nSound Event Injector : \n- great tool for modding sounds \n- no patches are needed \n- updating get much easier &amp; faster</InternalNotes>
-        <Description>Sound Event Injector : \n\nWillster: \nI dont know what we do with tthe Sound Event Injector Versions (script-file)\nBank-loader isnt used here &amp; In Relhax - not necessary \n- take audio.xml/engine.config.xml\n\n (no original files by WG as template)</Description>
-        <Medias>
-          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/Pe5njjXegUM?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/kqOTdQ9OlIw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_Gun_WWIIHWA" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds [by  {author}]" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_StarTrekPhaser" Enabled="True" InstallGroup="4" PatchGroup="4" UID="eimp66yqukiyphuk" Name="Star Trek Phasers v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+        <Size>7744194</Size>
+        <Version>6.2831</Version>
+        <ZipFile>Sound_Mods_Gun_Sounds_The_Illusion_Star_Trek_Weapons_2019-05-04.zip</ZipFile>
+        <CRC>f588548e2b9dac3f8138cedd7c3607d5</CRC>
+        <DevURL>http://forum.worldoftanks.com/index.php?/topic/602970-1412-phaser-gun-sounds/</DevURL>
+        <Author>The Illusion</Author>
+        <Description>Changes all guns to be more phasery!</Description>
+        <UpdateComment>V6.2831 - Added to "Effects" volume slider\nV3.1415 Updated all sounds to be better quality</UpdateComment>
+      </Package>
+      <Package PackageName="Sounds_Gun_Wrath" Enabled="True" InstallGroup="4" PatchGroup="4" UID="8x3wxao9p3ko09cy" Name="Wrath Of The Gods v{version} [by {author}]" Type="single_dropdown1" Visible="True">
+        <Size>3747536</Size>
+        <Version>2.314</Version>
+        <ZipFile>Sound_Mods_Gun_Sounds_TheIllusion_Wrath_V2.314_1.5.1.1_2019-06-24.zip</ZipFile>
+        <CRC>b24279ceec70ddd7b0980d1876250489</CRC>
+        <Timestamp>132024199381905502</Timestamp>
+        <DevURL>http://forum.worldoftanks.com/index.php?/topic/604225-1501-wrath-of-the-gods-gun-sound-mod</DevURL>
+        <Author>The Illusion</Author>
+        <Description>This will make guns sound real. And scary....</Description>
+        <UpdateComment>V2.0 - Changed "NPC" Sounds to sound different, Changed 139mm+ guns sounds (Now will make you jump the first time....)</UpdateComment>
+        <Medias>
+          <Media URL="https://youtu.be/J3v3TZhLk4I" MediaType="Webpage" />
+        </Medias>
+      </Package>
+      <Package PackageName="Sounds_Gun_WWIIHWA" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA v{version} [by {author}]" Type="single_dropdown1" Visible="True">
         <Size>15210784</Size>
         <Version>4.09</Version>
         <ZipFile>Sounds_WWIIHWA_Gunsounds_v4.09_1.7.1.0_2020-01-29.zip</ZipFile>
@@ -970,6 +922,26 @@
         <UpdateComment>Update 4.07 [1.6.1.0]:  DualGunReload topic (maybe usefull for other gunssounds)\r\nscripts\item_defs\vehicles\common\gun_reload_effects.xml\dualgun_reload115_152\r\n\r\nUpdate 4.06 [1.1.0.0]: Soundbanks to Wwise 2017.2.5, Soundbanks (new):  4.06</UpdateComment>
         <Medias>
           <Media URL="http://bigmods.relhaxmodpack.com/WoT/Medias/Pictures/Sounds_WWIIHWA_Guns_by_KT+Budyx69_Mod.png" MediaType="Picture" />
+        </Medias>
+      </Package>
+      <Package PackageName="Sounds_Gun_AGQJ_SoundinjektorNOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="chtydgsecrt2m65n" Name="NOTES: AGQJ Gun Sounds by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+        <Size>95845585</Size>
+        <Version>1502</Version>
+        <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_1.5.0.2_2019-05-18.zip</ZipFile>
+        <CRC>8ac233a3e08255f8865e948239456cbb</CRC>
+        <Timestamp>132207969933092634</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
+        <Description>Editor test: Hallo Relhax V2 - grown up from childish beta status</Description>
+      </Package>
+      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="wanzliuz53grxm10" Name="NOTES: Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
+        <Size>34224145</Size>
+        <Timestamp>131701182641902565</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>
+        <InternalNotes>Dont use this version(PYmods_BanksLoader) with WWIIHWA: \n- Sound Event Injector is incompatible with WWIIHWA\n- "WoT-Circle": Restart -&gt; Crash -&gt; Restart -&gt; Crash....)\nSound Event Injector : \n- great tool for modding sounds \n- no patches are needed \n- updating get much easier &amp; faster</InternalNotes>
+        <Description>Sound Event Injector : \n\nWillster: \nI dont know what we do with tthe Sound Event Injector Versions (script-file)\nBank-loader isnt used here &amp; In Relhax - not necessary \n- take audio.xml/engine.config.xml\n\n (no original files by WG as template)</Description>
+        <Medias>
+          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
         </Medias>
       </Package>
     </Packages>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -642,136 +642,67 @@
       </Package>
       <Package PackageName="Sounds_CrewVoices_English" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lr70rss3bzqwwx8o" Name="English Crew Voices" Type="single1" Visible="True">
         <Packages>
-          <Package PackageName="Sounds_CrewVoices_English_JohnTankPL" Enabled="False" InstallGroup="4" PatchGroup="4" UID="ygdf0sy4avjew8fo" Name="English Crew Sounds by JohnTankPL" Type="single1" Visible="False">
-            <Size>25743715</Size>
-            <ZipFile>Sounds_Crew_Sounds_Dzwieki_zalogi_By_JohnTankPL.zip</ZipFile>
-            <CRC>963a2d37c84339aa8cd85cf13ce91d97</CRC>
-            <Timestamp>131987322114911464</Timestamp>
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/603317-audio-1411-dzwieki-zalogi/</DevURL>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_dukeNukem" Enabled="True" InstallGroup="4" PatchGroup="4" UID="svvmrvon5ek381x1" Name="Duke Nukem by Silgi" Type="single1" Visible="True">
-            <Size>13876468</Size>
-            <Version>1.10.1</Version>
-            <ZipFile>Sounds_Crew_Sounds_duke_nukem_by_Silgi_EN_1.1.0_2019-09-06.zip</ZipFile>
-            <CRC>cd86686e2e77d7529cd1bceb98c87ffd</CRC>
-            <Timestamp>131806675515689164</Timestamp>
-            <DevURL>https://wgmods.net/1014/details</DevURL>
-            <Description>Mods by Silgi: https://wgmods.net/search/?owner=138375</Description>
-            <UpdateComment>v1.10.1 = v1.10\nThe simple version has the audioww\voiceover.bnk included</UpdateComment>
-            <Medias>
-              <Media URL="https://youtu.be/BjDIlk-0ijI?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-            </Medias>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_DrDisrespect" Enabled="False" InstallGroup="4" PatchGroup="4" UID="5k11zvuo4bdl7d41" Name="Dr. Disrespect by SirSchmidt" Type="single1" Visible="False">
-            <Size>30034447</Size>
-            <ZipFile>Sounds_Crew_Sounds_Dr_Disrespect_2019-07-21.zip</ZipFile>
-            <CRC>00c4f15cd81500ce0bbdaac0494e3d9e</CRC>
-            <Timestamp>132082301791347159</Timestamp>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Julie" Enabled="True" InstallGroup="4" PatchGroup="4" UID="i98g7u0p37537pb1" Name="Julie Voice Pack by niserius" Type="single1" Visible="True">
-            <Size>855212</Size>
-            <ZipFile>Sounds_Julie_Voice_Pack_1.1.0.zip</ZipFile>
-            <CRC>3e6f728be539ef1f2901dfc7f680dbcd</CRC>
-            <Timestamp>131803112589913544</Timestamp>
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
-            <Description>\nJulie:\nMust have sound crew language set to "standard"</Description>
-            <UpdateComment>\nJulie:\nupdated by niserius</UpdateComment>
-            <Medias>
-              <Media URL="https://www.youtube.com/watch?v=J0uWJ1XKOvg?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-            </Medias>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_LeviathanEvent2017" Enabled="True" InstallGroup="4" PatchGroup="4" UID="cnpnzyq8yq7sjite" Name="Leviathan Event 2017" Type="single1" Visible="True">
-            <Size>4391124</Size>
-            <ZipFile>Sounds_Crew_voices_LEVIATHAN_EVENT_2017_by_psyartax_v1.3_2019-01-12.zip</ZipFile>
-            <CRC>a98526f93c4ecdac0896d1628d2af929</CRC>
-            <Timestamp>131917960812089040</Timestamp>
-            <DevURL>https://wgmods.net/2780/details</DevURL>
-            <Description>works for female crew\nDoesn’t work on Italian Tanks</Description>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_TerrorbladeOfDota" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pcw27xw9xnzajt0e" Name="Terrorblade of Dota 2" Type="single1" Visible="True">
-            <Size>7823901</Size>
-            <ZipFile>Sounds_Crew_Voices_Terrorblade_of_Dota_1.3.0.1_2019-02-04.zip</ZipFile>
-            <CRC>d06e948e7fbdb1e8383d0496bc62df3d</CRC>
-            <Timestamp>131937175724507529</Timestamp>
-            <DevURL>https://wgmods.net/2752/details</DevURL>
-            <Description>Let´s give them hell!</Description>
-            <Medias>
-              <Media URL="https://youtu.be/BurczXsbcM8" MediaType="Webpage" />
-            </Medias>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_MLGbase" Enabled="False" InstallGroup="4" PatchGroup="4" UID="jrd9z1mss610umir" Name="MLG Mod by Aimdrol (English sound and text)" Type="single1" Visible="True">
-            <Size>26113309</Size>
-            <ZipFile>Sounds_mlg_mod_voice_1.7.1.0_2020-01-29.zip</ZipFile>
-            <CRC>0fa8fc8fe27c70bc966f480cde9cd8b1</CRC>
-            <Timestamp>132247631589781323</Timestamp>
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/476721-</DevURL>
-            <Description>Must have sound crew language set to "standard"\nMLG EVERYWHERE\nAlso includes awesome visuals.</Description>
-            <Dependencies>
-              <Dependency PackageName="Dependency_MLG_bnk" NotFlag="False" Logic="OR" />
-              <Dependency PackageName="Dependency_MLG_englishLocalization" NotFlag="False" Logic="OR" />
-            </Dependencies>
+          <Package PackageName="Sounds_CrewVoices_English_Basic" Enabled="True" InstallGroup="4" PatchGroup="4" UID="1ca3pf40usxremun" Name="Basic" Type="single1" Visible="True">
             <Packages>
-              <Package PackageName="Sounds_crew_sounds_MLG_only_audio" Enabled="True" InstallGroup="4" PatchGroup="4" UID="wgko71str2thuypr" Name="audio only, no visuals" Type="single_dropdown1" Visible="True">
-                <Size>814</Size>
-                <ZipFile>Sounds_mlg_mod_voice_sound_only_patch.zip</ZipFile>
-                <CRC>c46a3d2c3701290363a0c7115ab63e37</CRC>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_MontyPython" Enabled="True" InstallGroup="4" PatchGroup="4" UID="534muim7qd86poiw" Name="Monty Python" Type="single_dropdown1" Visible="True">
+                <Size>18509836</Size>
+                <Version>3</Version>
+                <ZipFile>Sounds_Monty_Python_1.1.0.1.zip</ZipFile>
+                <CRC>ce12dbd1440f08c98f20a678f2d1ac7b</CRC>
+                <Timestamp>131838649055814220</Timestamp>
+                <DevURL>https://wgmods.net/621/details</DevURL>
               </Package>
-              <Package PackageName="Sounds_crew_sounds_MLG_audio_and_visuals" Enabled="True" InstallGroup="4" PatchGroup="4" UID="95r3f0yurzmzu9xr" Name="audio and visuals" Type="single_dropdown1" Visible="True" />
-            </Packages>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_RoadRashJailbreak" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3j8b74odliop52f4" Name="Road Rash: Jailbreak" Type="single1" Visible="True">
-            <Size>11668684</Size>
-            <ZipFile>Sounds_Crew_Voices_Road_Rash_Jailbreak_1.3.0.1_2019-01-29.zip</ZipFile>
-            <CRC>b6e8da25262537bb8a6a9cdf7523033b</CRC>
-            <Timestamp>131932574838605907</Timestamp>
-            <DevURL>https://wgmods.net/617/details</DevURL>
-            <Description>Author: slavyanin_vedmak\n\n(Note: the other 5 crew voices made by Author  slavyanin_vedmak are russian)</Description>
-            <Medias>
-              <Media URL="https://youtu.be/uUScqfIlnfY" MediaType="Webpage" />
-            </Medias>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_Relhax" Enabled="True" InstallGroup="4" PatchGroup="4" UID="g8fqf3ueleg65em4" Name="Relhax" Type="single1" Visible="True">
-            <Size>1127</Size>
-            <Version>24</Version>
-            <ZipFile>Sounds_Crew_Sounds_Relhax_Base_2019-08-03.zip</ZipFile>
-            <CRC>833c22c8e5824ec90bacfe5daa96e1e5</CRC>
-            <Timestamp>132093315025806866</Timestamp>
-            <DevURL>http://relicgaming.org/index.php?topic=697.0</DevURL>
-            <Description>Relhax:\nReplaces all crew sounds with hilarious out-of-context sound bytes from people of the RELIC gaming community</Description>
-            <Medias>
-              <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
-              <Media URL="https://www.youtube.com/v/9kCic4vXYIE?version=3&amp;autoplay=1" MediaType="Webpage" />
-            </Medias>
-            <Packages>
-              <Package PackageName="Sounds_CrewVoices_English_Relhax_Regular" Enabled="True" InstallGroup="4" PatchGroup="4" UID="txl5n30ekb8o5qt3" Name="standard" Type="single_dropdown1" Visible="True">
-                <Size>26885296</Size>
-                <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Regular_2019-07-21.zip</ZipFile>
-                <CRC>a3a6d1b96750852656959710fbdc645a</CRC>
-                <Timestamp>132082298508051632</Timestamp>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_Minions" Enabled="True" InstallGroup="4" PatchGroup="4" UID="isb13it8p90op0pw" Name="Minions Voice Pack" Type="single_dropdown1" Visible="True">
+                <Size>4435341</Size>
+                <Version>1.1.0</Version>
+                <ZipFile>Sounds_Minions_Voice_Pack_1.1.0.zip</ZipFile>
+                <CRC>3717c6875371c4371663acc18d6b19bb</CRC>
+                <Timestamp>131803112711823360</Timestamp>
+                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12029-</DevURL>
+                <Description>Author: Mick42 and Andre_V; \nThis mod changes the standard voice acting crew sounds (screams, laughter, singing, dancing with a tambourine, etc.) minions film “Despicable Me” and “Despicable Me 2”. \n\nOld URL: http://worldof-tanks.com/8-10-minions-voicepack/</Description>
+                <UpdateComment>Updated: 2018-01-11 v0.9.21.0.3</UpdateComment>
+                <Medias>
+                  <Media URL="http://wotsite.net/images/2013/12/9/8.jpg" MediaType="Picture" />
+                  <Media URL="https://youtu.be/_0M0zLdKU3U?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                  <Media URL="https://youtu.be/7wKusFTzuy4?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
               </Package>
-              <Package PackageName="Sounds_CrewVoices_English_Relhax_Censored" Enabled="True" InstallGroup="4" PatchGroup="4" UID="nc3cf7qxfuaegjbg" Name="censored" Type="single_dropdown1" Visible="True">
-                <Size>23035297</Size>
-                <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Censored_2019-07-21.zip</ZipFile>
-                <CRC>5d521283ea13fcac23b7a3d01fe1cc90</CRC>
-                <Timestamp>132082298431317625</Timestamp>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_Sabaton" Enabled="True" InstallGroup="4" PatchGroup="4" UID="vhigbhz9o5s6pcwv" Name="Sabaton Voices" Type="single_dropdown1" Visible="True">
+                <Size>3793558</Size>
+                <ZipFile>Sounds_Sabaton_Crew_Voices_by_Andre_V_1.1.0_2018-08-31.zip</ZipFile>
+                <CRC>edad9c3775f51a1e507861b1fe08261d</CRC>
+                <Timestamp>131802423555074634</Timestamp>
+                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12427-</DevURL>
+                <Description>Change the default voice of all crews to Sabaton Primo Victoria</Description>
+                <UpdateComment>Updated 1.10 2018-08-31</UpdateComment>
+                <Medias>
+                  <Media URL="https://youtu.be/iT8MCiY44DA?version=3&amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
               </Package>
-            </Packages>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_mightyJingles" Enabled="True" InstallGroup="4" PatchGroup="4" UID="019rn6wyeq3vguig" Name="The Mighty Jingles Voice Pack revived by niserius" Type="single1" Visible="True">
-            <Size>19478898</Size>
-            <ZipFile>Sounds_mighty_jingles_Voice_Pack_1.1.0.zip</ZipFile>
-            <CRC>f346e22d46dd5a6952b3507ff77a83a8</CRC>
-            <Timestamp>131807564554552562</Timestamp>
-            <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan" Enabled="True" InstallGroup="4" PatchGroup="4" UID="ufryfamh994lrn0t" Name="English Crew Voices by The_Illusive_Man" Type="single1" Visible="True">
-            <Version>2018-10-02</Version>
-            <Timestamp>131931517940589771</Timestamp>
-            <DevURL>http://forum.worldoftanks.com/index.php?/topic/587664-star-trek-sound-mod/</DevURL>
-            <Dependencies>
-              <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-            </Dependencies>
-            <Packages>
+              <Package PackageName="Sounds_CrewVoices_English_AndreV_SteelFoxes" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pwzo2lpsjpuv05e8" Name="Steel Foxes with Strategic Music" Type="single_dropdown1" Visible="True">
+                <Size>24761023</Size>
+                <ZipFile>Sounds_crew_sounds_Steel_Foxes_by_Strategic_Music+Andre_V_english_1.1.0_2018-08-31.zip</ZipFile>
+                <CRC>13f6d2ab5f05ab7620acf8788f9e7fcc</CRC>
+                <Timestamp>131803109527255587</Timestamp>
+                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/10241-</DevURL>
+                <Description>Steel Foxes with Strategic Music &amp; Andre_V\nNote for youtube: Just wait ca. 20 seconds (russian language over)\n-provides alternative voice reactions from the tank crew. \n-More than 750 phrases for 45 different in-game situations.\n-gives you a new gaming experience\n-new emotions, atmosphere and some humor\n\nThe mod team:\nDmitry Kuzmenko – original idea, voice direction, script writing\nWill Bucknum – script writing, voice direction\nAaron Baca – script writing\nTechnical director – Serge Eybog\nSound design – Andrew Burmistrov, Stas Polesko, Petr Yakyamsev\nDouglas Pullar – commander\nJohn Bell – additional voice-over</Description>
+                <UpdateComment>Updated 1.10 2018-08-31\n\n\nRemoved ekspont_load.wotmod &amp; LobbyApi.wotmod</UpdateComment>
+                <Medias>
+                  <Media URL="http://wotsite.net/images/2013/11/25/13.jpg" MediaType="Picture" />
+                  <Media URL="https://youtu.be/565ek6lrqbo?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+                <Dependencies>
+                  <Dependency PackageName="Dependency_XML_audioMods" NotFlag="False" Logic="OR" />
+                </Dependencies>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_AllFemale" Enabled="False" InstallGroup="4" PatchGroup="4" UID="y0g0vfqnwxezektj" Name="Elkano's All Female Voices (ElkAFV)" Type="single_dropdown1" Visible="False">
+                <Size>1580</Size>
+                <ZipFile>Sounds_Elkanos_All_Female_Crew_Voices_(ElkAFV).zip</ZipFile>
+                <CRC>bf50b80e62b54ffadd5a643ed577a800</CRC>
+                <DevURL>https://mods.curse.com/wot-mods/worldoftanks/269045-elkafv</DevURL>
+                <Description>ElkAFV:  Very, very quiet, quiet as hell\nChange the default voice gender of all crews to female\n\nElkano: Very, very quiet, quiet as hell\nChange the default voice of all crews</Description>
+                <UpdateComment>\nElkano:\nElkASV:updated to 0.9.20.0\nElkAFV:\nv1.0 - updated to 0.9.19.0.1</UpdateComment>
+              </Package>
               <Package PackageName="Sounds_CrewVoices_English_TheIllusiveMan_Combined" Enabled="True" InstallGroup="4" PatchGroup="4" UID="74xdn9si86x3rz7t" Name="Combined Crew Sounds (Read Description)" Type="single_dropdown1" Visible="True">
                 <Size>11618720</Size>
                 <Version>2020-02-27</Version>
@@ -826,68 +757,131 @@
                   <Media URL="https://youtu.be/DqgGGayokfM" MediaType="Webpage" />
                 </Medias>
               </Package>
+              <Package PackageName="Sounds_CrewVoices_English_mightyJingles" Enabled="True" InstallGroup="4" PatchGroup="4" UID="019rn6wyeq3vguig" Name="The Mighty Jingles Voice Pack revived by niserius" Type="single_dropdown1" Visible="True">
+                <Size>19478898</Size>
+                <ZipFile>Sounds_mighty_jingles_Voice_Pack_1.1.0.zip</ZipFile>
+                <CRC>f346e22d46dd5a6952b3507ff77a83a8</CRC>
+                <Timestamp>131807564554552562</Timestamp>
+                <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_RoadRashJailbreak" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3j8b74odliop52f4" Name="Road Rash: Jailbreak" Type="single_dropdown1" Visible="True">
+                <Size>11668684</Size>
+                <ZipFile>Sounds_Crew_Voices_Road_Rash_Jailbreak_1.3.0.1_2019-01-29.zip</ZipFile>
+                <CRC>b6e8da25262537bb8a6a9cdf7523033b</CRC>
+                <Timestamp>131932574838605907</Timestamp>
+                <DevURL>https://wgmods.net/617/details</DevURL>
+                <Description>Author: slavyanin_vedmak\n\n(Note: the other 5 crew voices made by Author  slavyanin_vedmak are russian)</Description>
+                <Medias>
+                  <Media URL="https://youtu.be/uUScqfIlnfY" MediaType="Webpage" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_TerrorbladeOfDota" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pcw27xw9xnzajt0e" Name="Terrorblade of Dota 2" Type="single_dropdown1" Visible="True">
+                <Size>7823901</Size>
+                <ZipFile>Sounds_Crew_Voices_Terrorblade_of_Dota_1.3.0.1_2019-02-04.zip</ZipFile>
+                <CRC>d06e948e7fbdb1e8383d0496bc62df3d</CRC>
+                <Timestamp>131937175724507529</Timestamp>
+                <DevURL>https://wgmods.net/2752/details</DevURL>
+                <Description>Let´s give them hell!</Description>
+                <Medias>
+                  <Media URL="https://youtu.be/BurczXsbcM8" MediaType="Webpage" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_LeviathanEvent2017" Enabled="True" InstallGroup="4" PatchGroup="4" UID="cnpnzyq8yq7sjite" Name="Leviathan Event 2017" Type="single_dropdown1" Visible="True">
+                <Size>4391124</Size>
+                <ZipFile>Sounds_Crew_voices_LEVIATHAN_EVENT_2017_by_psyartax_v1.3_2019-01-12.zip</ZipFile>
+                <CRC>a98526f93c4ecdac0896d1628d2af929</CRC>
+                <Timestamp>131917960812089040</Timestamp>
+                <DevURL>https://wgmods.net/2780/details</DevURL>
+                <Description>works for female crew\nDoesn’t work on Italian Tanks</Description>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_Julie" Enabled="True" InstallGroup="4" PatchGroup="4" UID="i98g7u0p37537pb1" Name="Julie Voice Pack by niserius" Type="single_dropdown1" Visible="True">
+                <Size>855212</Size>
+                <ZipFile>Sounds_Julie_Voice_Pack_1.1.0.zip</ZipFile>
+                <CRC>3e6f728be539ef1f2901dfc7f680dbcd</CRC>
+                <Timestamp>131803112589913544</Timestamp>
+                <DevURL>http://forum.worldoftanks.eu/index.php?/topic/559722-</DevURL>
+                <Description>\nJulie:\nMust have sound crew language set to "standard"</Description>
+                <UpdateComment>\nJulie:\nupdated by niserius</UpdateComment>
+                <Medias>
+                  <Media URL="https://www.youtube.com/watch?v=J0uWJ1XKOvg?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_DrDisrespect" Enabled="False" InstallGroup="4" PatchGroup="4" UID="5k11zvuo4bdl7d41" Name="Dr. Disrespect by SirSchmidt" Type="single_dropdown1" Visible="False">
+                <Size>30034447</Size>
+                <ZipFile>Sounds_Crew_Sounds_Dr_Disrespect_2019-07-21.zip</ZipFile>
+                <CRC>00c4f15cd81500ce0bbdaac0494e3d9e</CRC>
+                <Timestamp>132082301791347159</Timestamp>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_dukeNukem" Enabled="True" InstallGroup="4" PatchGroup="4" UID="svvmrvon5ek381x1" Name="Duke Nukem by Silgi" Type="single_dropdown1" Visible="True">
+                <Size>13876468</Size>
+                <Version>1.10.1</Version>
+                <ZipFile>Sounds_Crew_Sounds_duke_nukem_by_Silgi_EN_1.1.0_2019-09-06.zip</ZipFile>
+                <CRC>cd86686e2e77d7529cd1bceb98c87ffd</CRC>
+                <Timestamp>131806675515689164</Timestamp>
+                <DevURL>https://wgmods.net/1014/details</DevURL>
+                <Description>Mods by Silgi: https://wgmods.net/search/?owner=138375</Description>
+                <UpdateComment>v1.10.1 = v1.10\nThe simple version has the audioww\voiceover.bnk included</UpdateComment>
+                <Medias>
+                  <Media URL="https://youtu.be/BjDIlk-0ijI?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_JohnTankPL" Enabled="False" InstallGroup="4" PatchGroup="4" UID="ygdf0sy4avjew8fo" Name="English Crew Sounds by JohnTankPL" Type="single_dropdown1" Visible="False">
+                <Size>25743715</Size>
+                <ZipFile>Sounds_Crew_Sounds_Dzwieki_zalogi_By_JohnTankPL.zip</ZipFile>
+                <CRC>963a2d37c84339aa8cd85cf13ce91d97</CRC>
+                <Timestamp>131987322114911464</Timestamp>
+                <DevURL>http://forum.worldoftanks.eu/index.php?/topic/603317-audio-1411-dzwieki-zalogi/</DevURL>
+              </Package>
             </Packages>
           </Package>
-          <Package PackageName="Sounds_CrewVoices_English_AllFemale" Enabled="False" InstallGroup="4" PatchGroup="4" UID="y0g0vfqnwxezektj" Name="Elkano's All Female Voices (ElkAFV)" Type="single1" Visible="False">
-            <Size>1580</Size>
-            <ZipFile>Sounds_Elkanos_All_Female_Crew_Voices_(ElkAFV).zip</ZipFile>
-            <CRC>bf50b80e62b54ffadd5a643ed577a800</CRC>
-            <DevURL>https://mods.curse.com/wot-mods/worldoftanks/269045-elkafv</DevURL>
-            <Description>ElkAFV:  Very, very quiet, quiet as hell\nChange the default voice gender of all crews to female\n\nElkano: Very, very quiet, quiet as hell\nChange the default voice of all crews</Description>
-            <UpdateComment>\nElkano:\nElkASV:updated to 0.9.20.0\nElkAFV:\nv1.0 - updated to 0.9.19.0.1</UpdateComment>
-          </Package>
-          <Package PackageName="Sounds_CrewVoices_English_AndreV" Enabled="True" InstallGroup="4" PatchGroup="4" UID="bpnf3fwovu6hev0j" Name="English Crew Voices by Andre_V" Type="single1" Visible="True">
+          <Package PackageName="Sounds_CrewVoices_English_Advanced" Enabled="True" InstallGroup="4" PatchGroup="4" UID="isfopklgm7kttpte" Name="Advanced" Type="single1" Visible="True">
             <Packages>
-              <Package PackageName="Sounds_CrewVoices_English_AndreV_MontyPython" Enabled="True" InstallGroup="4" PatchGroup="4" UID="534muim7qd86poiw" Name="Monty Python" Type="single_dropdown1" Visible="True">
-                <Size>18509836</Size>
-                <Version>3</Version>
-                <ZipFile>Sounds_Monty_Python_1.1.0.1.zip</ZipFile>
-                <CRC>ce12dbd1440f08c98f20a678f2d1ac7b</CRC>
-                <Timestamp>131838649055814220</Timestamp>
-                <DevURL>https://wgmods.net/621/details</DevURL>
-              </Package>
-              <Package PackageName="Sounds_CrewVoices_English_AndreV_Minions" Enabled="True" InstallGroup="4" PatchGroup="4" UID="isb13it8p90op0pw" Name="Minions Voice Pack" Type="single_dropdown1" Visible="True">
-                <Size>4435341</Size>
-                <Version>1.1.0</Version>
-                <ZipFile>Sounds_Minions_Voice_Pack_1.1.0.zip</ZipFile>
-                <CRC>3717c6875371c4371663acc18d6b19bb</CRC>
-                <Timestamp>131803112711823360</Timestamp>
-                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12029-</DevURL>
-                <Description>Author: Mick42 and Andre_V; \nThis mod changes the standard voice acting crew sounds (screams, laughter, singing, dancing with a tambourine, etc.) minions film “Despicable Me” and “Despicable Me 2”. \n\nOld URL: http://worldof-tanks.com/8-10-minions-voicepack/</Description>
-                <UpdateComment>Updated: 2018-01-11 v0.9.21.0.3</UpdateComment>
-                <Medias>
-                  <Media URL="http://wotsite.net/images/2013/12/9/8.jpg" MediaType="Picture" />
-                  <Media URL="https://youtu.be/_0M0zLdKU3U?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-                  <Media URL="https://youtu.be/7wKusFTzuy4?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-                </Medias>
-              </Package>
-              <Package PackageName="Sounds_CrewVoices_English_AndreV_Sabaton" Enabled="True" InstallGroup="4" PatchGroup="4" UID="vhigbhz9o5s6pcwv" Name="Sabaton Voices" Type="single_dropdown1" Visible="True">
-                <Size>3793558</Size>
-                <ZipFile>Sounds_Sabaton_Crew_Voices_by_Andre_V_1.1.0_2018-08-31.zip</ZipFile>
-                <CRC>edad9c3775f51a1e507861b1fe08261d</CRC>
-                <Timestamp>131802423555074634</Timestamp>
-                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/12427-</DevURL>
-                <Description>Change the default voice of all crews to Sabaton Primo Victoria</Description>
-                <UpdateComment>Updated 1.10 2018-08-31</UpdateComment>
-                <Medias>
-                  <Media URL="https://youtu.be/iT8MCiY44DA?version=3&amp;autoplay=1" MediaType="Webpage" />
-                </Medias>
-              </Package>
-              <Package PackageName="Sounds_CrewVoices_English_AndreV_SteelFoxes" Enabled="True" InstallGroup="4" PatchGroup="4" UID="pwzo2lpsjpuv05e8" Name="Steel Foxes with Strategic Music" Type="single_dropdown1" Visible="True">
-                <Size>24761023</Size>
-                <ZipFile>Sounds_crew_sounds_Steel_Foxes_by_Strategic_Music+Andre_V_english_1.1.0_2018-08-31.zip</ZipFile>
-                <CRC>13f6d2ab5f05ab7620acf8788f9e7fcc</CRC>
-                <Timestamp>131803109527255587</Timestamp>
-                <DevURL>http://wotsite.net/ozvuchka-dlya-world-of-tanks/10241-</DevURL>
-                <Description>Steel Foxes with Strategic Music &amp; Andre_V\nNote for youtube: Just wait ca. 20 seconds (russian language over)\n-provides alternative voice reactions from the tank crew. \n-More than 750 phrases for 45 different in-game situations.\n-gives you a new gaming experience\n-new emotions, atmosphere and some humor\n\nThe mod team:\nDmitry Kuzmenko – original idea, voice direction, script writing\nWill Bucknum – script writing, voice direction\nAaron Baca – script writing\nTechnical director – Serge Eybog\nSound design – Andrew Burmistrov, Stas Polesko, Petr Yakyamsev\nDouglas Pullar – commander\nJohn Bell – additional voice-over</Description>
-                <UpdateComment>Updated 1.10 2018-08-31\n\n\nRemoved ekspont_load.wotmod &amp; LobbyApi.wotmod</UpdateComment>
-                <Medias>
-                  <Media URL="http://wotsite.net/images/2013/11/25/13.jpg" MediaType="Picture" />
-                  <Media URL="https://youtu.be/565ek6lrqbo?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-                </Medias>
+              <Package PackageName="Sounds_CrewVoices_English_MLGbase" Enabled="False" InstallGroup="4" PatchGroup="4" UID="jrd9z1mss610umir" Name="MLG Mod by Aimdrol (English sound and text)" Type="single1" Visible="True">
+                <Size>26113309</Size>
+                <ZipFile>Sounds_mlg_mod_voice_1.7.1.0_2020-01-29.zip</ZipFile>
+                <CRC>0fa8fc8fe27c70bc966f480cde9cd8b1</CRC>
+                <Timestamp>132247631589781323</Timestamp>
+                <DevURL>http://forum.worldoftanks.eu/index.php?/topic/476721-</DevURL>
+                <Description>Must have sound crew language set to "standard"\nMLG EVERYWHERE\nAlso includes awesome visuals.</Description>
                 <Dependencies>
-                  <Dependency PackageName="Dependency_XML_audioMods" NotFlag="False" Logic="OR" />
+                  <Dependency PackageName="Dependency_MLG_bnk" NotFlag="False" Logic="OR" />
+                  <Dependency PackageName="Dependency_MLG_englishLocalization" NotFlag="False" Logic="OR" />
                 </Dependencies>
+                <Packages>
+                  <Package PackageName="Sounds_crew_sounds_MLG_only_audio" Enabled="True" InstallGroup="4" PatchGroup="4" UID="wgko71str2thuypr" Name="audio only, no visuals" Type="single_dropdown1" Visible="True">
+                    <Size>814</Size>
+                    <ZipFile>Sounds_mlg_mod_voice_sound_only_patch.zip</ZipFile>
+                    <CRC>c46a3d2c3701290363a0c7115ab63e37</CRC>
+                  </Package>
+                  <Package PackageName="Sounds_crew_sounds_MLG_audio_and_visuals" Enabled="True" InstallGroup="4" PatchGroup="4" UID="95r3f0yurzmzu9xr" Name="audio and visuals" Type="single_dropdown1" Visible="True" />
+                </Packages>
+              </Package>
+              <Package PackageName="Sounds_CrewVoices_English_Relhax" Enabled="True" InstallGroup="4" PatchGroup="4" UID="g8fqf3ueleg65em4" Name="Relhax" Type="single1" Visible="True">
+                <Size>1127</Size>
+                <Version>24</Version>
+                <ZipFile>Sounds_Crew_Sounds_Relhax_Base_2019-08-03.zip</ZipFile>
+                <CRC>833c22c8e5824ec90bacfe5daa96e1e5</CRC>
+                <Timestamp>132093315025806866</Timestamp>
+                <DevURL>http://relicgaming.org/index.php?topic=697.0</DevURL>
+                <Description>Relhax:\nReplaces all crew sounds with hilarious out-of-context sound bytes from people of the RELIC gaming community</Description>
+                <Medias>
+                  <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
+                  <Media URL="https://www.youtube.com/v/9kCic4vXYIE?version=3&amp;autoplay=1" MediaType="Webpage" />
+                </Medias>
+                <Packages>
+                  <Package PackageName="Sounds_CrewVoices_English_Relhax_Regular" Enabled="True" InstallGroup="4" PatchGroup="4" UID="txl5n30ekb8o5qt3" Name="standard" Type="single_dropdown1" Visible="True">
+                    <Size>26885296</Size>
+                    <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Regular_2019-07-21.zip</ZipFile>
+                    <CRC>a3a6d1b96750852656959710fbdc645a</CRC>
+                    <Timestamp>132082298508051632</Timestamp>
+                  </Package>
+                  <Package PackageName="Sounds_CrewVoices_English_Relhax_Censored" Enabled="True" InstallGroup="4" PatchGroup="4" UID="nc3cf7qxfuaegjbg" Name="censored" Type="single_dropdown1" Visible="True">
+                    <Size>23035297</Size>
+                    <ZipFile>Sounds_Crew_Sounds_Relhax_Config_Censored_2019-07-21.zip</ZipFile>
+                    <CRC>5d521283ea13fcac23b7a3d01fe1cc90</CRC>
+                    <Timestamp>132082298431317625</Timestamp>
+                  </Package>
+                </Packages>
               </Package>
             </Packages>
           </Package>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -614,7 +614,7 @@
       <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
     </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_Engines_AGQJ" Enabled="True" InstallGroup="4" PatchGroup="2" UID="5dmxfmdt2b0lnhm2" Name="AGQJ v{version}" Type="single1" Visible="False">
+      <Package PackageName="Sounds_Engines_AGQJ" Enabled="True" InstallGroup="4" PatchGroup="2" UID="5dmxfmdt2b0lnhm2" Name="AGQJ v{version}" Type="single1" Visible="True">
         <Size>83686458</Size>
         <Version>234</Version>
         <ZipFile>Sounds_Engines_AGQJ_v234_1.9.0.0_2020-04-23.zip</ZipFile>
@@ -806,7 +806,7 @@
         <Author>Violence</Author>
         <Description>All sounds are inherited from the original WoT 0.9.13 client.\n\nCovered sounds: 45mm, 76mm, 100mm, 122mm, 152mm\n\nSorry, no autocannon sounds yet.</Description>
       </Package>
-      <Package PackageName="Sounds_Guns_AGQJ" Enabled="True" InstallGroup="4" PatchGroup="2" UID="by4pnina7sywco5o" Name="AGQJ v{version}" Type="single1" Visible="False">
+      <Package PackageName="Sounds_Guns_AGQJ" Enabled="True" InstallGroup="4" PatchGroup="2" UID="by4pnina7sywco5o" Name="AGQJ v{version}" Type="single1" Visible="True">
         <Size>96202544</Size>
         <Version>234</Version>
         <ZipFile>Sounds_Guns_AGQJ_v234_1.9.0.0_2020-04-23.zip</ZipFile>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -4,312 +4,6 @@
     <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_default" NotFlag="False" Logic="OR" />
     <Dependency PackageName="Dependency_XML_audioMods" NotFlag="False" Logic="OR" />
   </Dependencies>
-  <Package PackageName="Sounds_Engine" Enabled="True" InstallGroup="4" PatchGroup="4" UID="j1ezivwfk4sogzg5" Name="Engine" Type="multi" Visible="True">
-    <Dependencies>
-      <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-    </Dependencies>
-    <Packages>
-      <Package PackageName="Sounds_AGQJ_Engines_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ Engines by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
-        <Size>8141</Size>
-        <Version>234</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>ee7fe89423b7a52dc1a0ef08152707ff</CRC>
-        <Timestamp>132321454605017775</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
-        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <UpdateComment>T10 Fix"V-12-6": \r\n{                "wwsoundPC": "V_12P",\r\n                "wwsoundNPC": "V_12P_NPC"           },\r\n\r\nUpdate  G&amp;M  V230  ( 04.03.2020 )</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_AGQJ_Engines_Fedor_Saveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ Engines by Fedor Saveliev" Type="single_dropdown1" Visible="True">
-        <Size>22014</Size>
-        <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_Mister_bl_614_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>af6ac123ab4eb60423ffd936e9152ee3</CRC>
-        <Timestamp>132327454379581360</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
-        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <Dependencies>
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Engines_by_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
-        <Size>21658356</Size>
-        <Version>1.2.0.1</Version>
-        <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.2.0.1_2018-10-18.zip</ZipFile>
-        <CRC>942fcf6e4b5137d576aecdcb13f9675b</CRC>
-        <Timestamp>131843677273540576</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
-        <UpdateComment>1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Engines_HRMOD_GnomeFather_Zorgane" Enabled="True" InstallGroup="4" PatchGroup="4" UID="x8q7i2oj8zh328uv" Name="GnomeFather’s HRMOD Engines Sounds (reworked by Zorgane)  v{version}" Type="single_dropdown1" Visible="True">
-        <Size>3065</Size>
-        <Version>3.00</Version>
-        <ZipFile>Sounds_Engines_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
-        <CRC>9622f81b69bb2ad67409094a9928769e</CRC>
-        <Timestamp>132325073809233568</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
-        <InternalNotes>own soundbanks by Zorgane:\naudioww\Zorg_Guns_Engines.bnk\naudioww\Zorg_Guns_Engines.pck\n\nmoded scripts\nscripts\item_defs\vehicles\r\n\r\nhttps://www.mediafire.com/folder/dh5bf45314xfo/Gnomefather's_HRMOD</InternalNotes>
-        <Description>Dont forget : I (Zorgane) need reviews ! - use devolper website to do this please\n\nNote : Scripts for remodels are unavailable for the moment.</Description>
-        <UpdateComment>V. 2.18 Added FV/T95 custom sounds\r\nFixed german HL234 engine\r\n\r\nV. 2.16 Fixed scripts for xmas style\r\nFixed Panther turbo engine sound\r\nFixed missing french engine sounds\r\n\r\nV.2.15: Added engine sounds for some american tanks\r\nV.2.14: Added support for Super Hellcat\r\n\r\nV. 2.10 Patchnote Compatibility with 1.6.0.2\r\nFixed leopard engine sound\r\nFixed T-116 gun sound\r\nAdded 64bit memory profile\r\n</UpdateComment>
-        <Medias>
-          <Media URL="http://image.noelshack.com/fichiers/2017/20/1495072185-config.jpg" MediaType="Picture" />
-          <Media URL="https://youtu.be/V7G2JDB07Lw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_AGQJ_Engines_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
-        <Size>83692900</Size>
-        <Version>1.2.0.0</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.2.0_2018-10-12.zip</ZipFile>
-        <CRC>f81a45d6cad2f9baa0d9eb0b4503681d</CRC>
-        <Timestamp>131774181890246272</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
-      </Package>
-      <Package PackageName="Sounds_AGQJ_Engines" Enabled="False" InstallGroup="4" PatchGroup="4" UID="4ceui5k32fbaedj8" Name="AGQJ Engines by Fedor Saveliev  v{version}" Type="single_dropdown1" Visible="False">
-        <Size>83692297</Size>
-        <Version>1.5.0.2</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.2_2019-05-15.zip</ZipFile>
-        <CRC>704f4f3656a7356f17c0f1f44a009ef9</CRC>
-        <Timestamp>131940420589802487</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>direct link:Engines  (no SoundEventInjector)\nhttps://yadi.sk/d/mqjb17bGynH6V\n\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Engines_by_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="h1k8q4q42b3sepq8" Name="NOTES: Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
-        <Size>21654503</Size>
-        <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.1.0_2018-08-31.zip</ZipFile>
-        <CRC>dfb5e70f2e91630d08e92fc01ff0d1ea</CRC>
-        <Timestamp>131838128329867008</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>
-        <InternalNotes>Dont use PYmods_BanksLoader with WWIIHWA: \n- Sound Event Injector is incompatible with WWIIHWA\n- "WoT-Circle": Restart -&gt; Crash -&gt; Restart -&gt; Crash....)\nSound Event Injector : \n- great tool for modding sounds \n- no patches are needed \n- updating get much easier &amp; faster</InternalNotes>
-        <Description>Sound Event Injector : \n\nWillster: \nI dont know what we do with tthe Sound Event Injector Versions (script-file)\nBank-loader isnt used here &amp; In Relhax - not necessary \n- take audio.xml/engine.config.xml\n\n (no original files by WG as template)</Description>
-        <Medias>
-          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-      </Package>
-    </Packages>
-  </Package>
-  <Package PackageName="Sounds_GUI" Enabled="True" InstallGroup="4" PatchGroup="4" UID="uqrny4w518w9e0y8" Name="GUI" Type="multi" Visible="True">
-    <Packages>
-      <Package PackageName="Sounds_GUI_Relhax" Enabled="True" InstallGroup="4" PatchGroup="4" UID="o49vq8mowrxzptgl" Name="Relhax by Willster419" Type="single_dropdown1" Visible="True">
-        <Size>35069225</Size>
-        <ZipFile>Sounds_GUI_Sounds_Relhax_2019-07-21.zip</ZipFile>
-        <CRC>7c7bbcb6b31c32be3be546fe7b600813</CRC>
-        <Timestamp>132082299682684028</Timestamp>
-        <Medias>
-          <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-    </Packages>
-  </Package>
-  <Package PackageName="Sounds_Gun" Enabled="True" InstallGroup="4" PatchGroup="4" UID="1tfay7spvnqhp5nl" Name="Gun" Type="multi" Visible="True">
-    <Dependencies>
-      <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-    </Dependencies>
-    <Packages>
-      <Package PackageName="Sounds_Gun_Star_Trek_Phaser" Enabled="True" InstallGroup="4" PatchGroup="4" UID="eimp66yqukiyphuk" Name="Star Trek Phasers by The Illusion v{version}" Type="single_dropdown1" Visible="True">
-        <Size>7744194</Size>
-        <Version>6.2831</Version>
-        <ZipFile>Sound_Mods_Gun_Sounds_The_Illusion_Star_Trek_Weapons_2019-05-04.zip</ZipFile>
-        <CRC>f588548e2b9dac3f8138cedd7c3607d5</CRC>
-        <DevURL>http://forum.worldoftanks.com/index.php?/topic/602970-1412-phaser-gun-sounds/</DevURL>
-        <Description>Changes all guns to be more phasery!</Description>
-        <UpdateComment>V6.2831 - Added to "Effects" volume slider\nV3.1415 Updated all sounds to be better quality</UpdateComment>
-      </Package>
-      <Package PackageName="Sounds_Gun_Wrath" Enabled="True" InstallGroup="4" PatchGroup="4" UID="8x3wxao9p3ko09cy" Name="Wrath Of The Gods by The Illusion v{version}" Type="single_dropdown1" Visible="True">
-        <Size>3747536</Size>
-        <Version>2.314</Version>
-        <ZipFile>Sound_Mods_Gun_Sounds_TheIllusion_Wrath_V2.314_1.5.1.1_2019-06-24.zip</ZipFile>
-        <CRC>b24279ceec70ddd7b0980d1876250489</CRC>
-        <Timestamp>132024199381905502</Timestamp>
-        <DevURL>http://forum.worldoftanks.com/index.php?/topic/604225-1501-wrath-of-the-gods-gun-sound-mod</DevURL>
-        <Description>This will make guns sound real. And scary....</Description>
-        <UpdateComment>V2.0 - Changed "NPC" Sounds to sound different, Changed 139mm+ guns sounds (Now will make you jump the first time....)</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/J3v3TZhLk4I" MediaType="Webpage" />
-        </Medias>
-      </Package>
-      <Package PackageName="Sounds_Gun_9.13" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lmab5auaozc60ljx" Name="_Violence_'s 0.9.13 Gun Sounds v{version}" Type="single_dropdown1" Visible="True">
-        <Size>2688534</Size>
-        <Version>1.0</Version>
-        <ZipFile>Sound_Gun_Sounds_By_Violence_1.4.1.1_2019-04-04.zip</ZipFile>
-        <CRC>92caf0d676d0f3e9f7e352d51da8157e</CRC>
-        <Timestamp>131988818715738838</Timestamp>
-        <DevURL>https://wgmods.net/3170/details</DevURL>
-        <Description>All sounds are inherited from the original WoT 0.9.13 client.\n\nCovered sounds: 45mm, 76mm, 100mm, 122mm, 152mm\n\nSorry, no autocannon sounds yet.</Description>
-      </Package>
-      <Package PackageName="Sounds_Gun_by_Shimada_Samas" Enabled="True" InstallGroup="4" PatchGroup="4" UID="f0rixektjievbe1b" Name="Gun Sounds by Shimada Samas" Type="single_dropdown1" Visible="True">
-        <Size>40928630</Size>
-        <Version>5.40</Version>
-        <ZipFile>Sound_Mods_Gun_by_Shimada_Samas_5.40_1.9.0.1_2020-04-26.zip</ZipFile>
-        <CRC>8a90413f14a768289cfcb9887c4977c6</CRC>
-        <Timestamp>132323646945848449</Timestamp>
-        <DevURL>https://wgmods.net/673/details</DevURL>
-        <Description>Gun Sounds by Shimada Samas /  _Shimada_Arisu_ \nI use gun sound from many source such as\n- Gnomefather\n- Battlefield\n- WarThunder\nand more.</Description>
-        <UpdateComment>Version 5.3.3 (2020-03-16)\r\n- Update for 1.8.0.1\r\n\r\nVersion 5.3.2 (2020-03-14)\r\n- Update for 1.8.0.0\r\nVersion 5.3.0\r\n- Update for 1.7.1.2 - Add gun sounds for double gun tanks\r\nVersion 5.20 (2020-01-13)\r\n- Update for 1.7.0.2 \r\n- Fix a 3D style skin bug for Jg.Pz.E100 and AMX 13 105 - Update Jg.Pz.E100 and AMX 13 105 script files</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/Pe5njjXegUM?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/kqOTdQ9OlIw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-      </Package>
-      <Package PackageName="Sounds_Gun_HRMOD_GnomeFather_Zorgane" Enabled="True" InstallGroup="4" PatchGroup="4" UID="spyx5dquif6dbq8a" Name="GnomeFather’s HRMOD Gun Sounds (reworked by Zorgane)  v{version}" Type="single_dropdown1" Visible="True">
-        <Size>15787</Size>
-        <Version>3.00</Version>
-        <ZipFile>Sounds_Gun_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
-        <CRC>814cbe031b312a74130c53ed6c1358d6</CRC>
-        <Timestamp>132325074171114003</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
-        <InternalNotes>These are now wotmods for conflicting reasons.\r\n\r\nown soundbanks by Zorgane:\naudioww\Zorg_Guns_Engines.bnk\naudioww\Zorg_Guns_Engines.pck\n\nmoded scripts\nscripts\item_defs\vehicles\r\n\r\nhttps://www.mediafire.com/folder/dh5bf45314xfo/Gnomefather's_HRMOD</InternalNotes>
-        <Description>This mod alters the sounds via the tanks xml's. This makes the mod break every patch. Expect some time for updates. Use Wrath of the Gods gun sounds, or Shimada if you want something that doesnt break every patch.\r\n\r\nDont forget : I (Zorgane) need reviews ! - use devolper website to do this please\n\n</Description>
-        <UpdateComment>V. 2.18 Added FV/T95 custom sounds\r\nFixed german HL234 engine\r\n\r\nV. 2.16 Fixed scripts for xmas style\r\nFixed Panther turbo engine sound\r\nFixed missing french engine sounds\r\n\r\nV.2.15: Added engine sounds for some american tanks\r\nV.2.14: Added support for Super Hellcat\r\n\r\nV. 2.10 Patchnote Compatibility with 1.6.0.2\r\nFixed leopard engine sound\r\nFixed T-116 gun sound\r\nAdded 64bit memory profile</UpdateComment>
-        <Medias>
-          <Media URL="http://image.noelshack.com/fichiers/2017/20/1495072185-config.jpg" MediaType="Picture" />
-          <Media URL="&lt;html&gt;&lt;head&gt;&lt;meta http-equiv='X-UA-Compatible' content='IE=11' /&gt;&lt;body&gt;&lt;iframe width=&quot;640&quot; height=&quot;360&quot; src=&quot;https://www.youtube.com/embed/V7G2JDB07Lw&quot; frameborder=&quot;0&quot; style=&quot;position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;&quot;&gt; Your browser doesn't support iFrames.&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" MediaType="HTML" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_AGQJ_Guns_by_Fedor_Saveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ Guns by Fedor Saveliev" Type="single_dropdown1" Visible="True">
-        <Size>13133</Size>
-        <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_AGQJ_Guns_by_FedorSaveliev_Only_Scripts_Mister_bl#614_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>1474a259478ddf461842fcc4a3f56dea</CRC>
-        <Timestamp>132321437159757811</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
-        <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_AGQJ_Guns_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ Guns by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
-        <Size>15995</Size>
-        <Version>234</Version>
-        <ZipFile>Sounds_AGQJ_Guns_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>b1af5ec72469a38d2283313e81b0ed7c</CRC>
-        <Timestamp>132321453467109357</Timestamp>
-        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
-        <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
-        <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_AGQJ_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="chtydgsecrt2m65n" Name="NOTES: AGQJ Gun Sounds by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
-        <Size>95845585</Size>
-        <Version>1502</Version>
-        <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_1.5.0.2_2019-05-18.zip</ZipFile>
-        <CRC>8ac233a3e08255f8865e948239456cbb</CRC>
-        <Timestamp>132207969933092634</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
-        <Description>Editor test: Hallo Relhax V2 - grown up from childish beta status</Description>
-      </Package>
-      <Package PackageName="Sounds_Gun_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="p6zdlfyfbnlkmicn" Name="AGQJ Gun Sounds by Fedor Saveliev v{version} (SoundEventInjector)" Type="single_dropdown1" Visible="False">
-        <Size>95868116</Size>
-        <Version>1.5.0.1</Version>
-        <ZipFile>Sounds_AGQJ_Gun_Sounds_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.1_2019-05-14.zip</ZipFile>
-        <CRC>2974ae69a73c8aa52f85a69ce016f6ab</CRC>
-        <Timestamp>131838144585727822</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>direct link :Gun_sounds (no SoundEventInjector)\nhttps://yadi.sk/d/GNoG0AI5sRcaq\n\ndirect link :Gun_sounds (SoundEventInjector)\nhttps://yadi.sk/d/2uTYjByN3TamTd\r\n\r\nmaybe confict with WWIIHWA</Description>
-        <Medias>
-          <Media URL="https://youtu.be/CUs8Z42fAK0?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/XN8A0MRqw0E?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/aS_Y26uJ0SA?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/l8Kd4KuvZFg?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/5bKlYtpVTuI?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/b9Uy9Qs7kGA?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/P9ISUHoYKMY?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/JpUQhbF2Tc8?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/EiNfm2AmBQY?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-          <Media URL="https://youtu.be/5EtBFvWcNQk?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jlhkdjoy66n9ybu0" Name="Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
-        <Size>34292701</Size>
-        <Version>1.8.0.0</Version>
-        <ZipFile>Sounds_Gun_GO_by_Ed76na+Apa6ecka_1.8.0.0_2020-03-04.zip</ZipFile>
-        <CRC>1b23db178c16b8eba059cd454b53c146</CRC>
-        <Timestamp>132278011144054309</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
-        <InternalNotes> (no original files by WG as template)</InternalNotes>
-        <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
-        <UpdateComment>2019-04-16: added HWK30, TS-5\n1412=1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
-        <Medias>
-          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-        <Dependencies>
-          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
-          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
-        </Dependencies>
-      </Package>
-      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="wanzliuz53grxm10" Name="NOTES: Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
-        <Size>34224145</Size>
-        <Timestamp>131701182641902565</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>
-        <InternalNotes>Dont use this version(PYmods_BanksLoader) with WWIIHWA: \n- Sound Event Injector is incompatible with WWIIHWA\n- "WoT-Circle": Restart -&gt; Crash -&gt; Restart -&gt; Crash....)\nSound Event Injector : \n- great tool for modding sounds \n- no patches are needed \n- updating get much easier &amp; faster</InternalNotes>
-        <Description>Sound Event Injector : \n\nWillster: \nI dont know what we do with tthe Sound Event Injector Versions (script-file)\nBank-loader isnt used here &amp; In Relhax - not necessary \n- take audio.xml/engine.config.xml\n\n (no original files by WG as template)</Description>
-        <Medias>
-          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
-        </Medias>
-      </Package>
-      <Package PackageName="Sounds_WWIIHWA_Guns_by_KT+Budyx69" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds by Budyx69 &amp; KT " Type="single_dropdown1" Visible="True">
-        <Size>15210784</Size>
-        <Version>4.09</Version>
-        <ZipFile>Sounds_WWIIHWA_Gunsounds_v4.09_1.7.1.0_2020-01-29.zip</ZipFile>
-        <CRC>f478eb4c26bb7bbfaa678102147d77fe</CRC>
-        <Timestamp>132248036037116996</Timestamp>
-        <DevURL>https://dieschwarzenschafe.com/download/Index.php?action=list&amp;dir=WWIIHWA%2FWWIIHWA+GunSounds&amp;order=name&amp;srt=yes\r\nhttp://forum.worldoftanks.eu/index.php?/topic/502495-</DevURL>
-        <UpdateComment>Update 4.07 [1.6.1.0]:  DualGunReload topic (maybe usefull for other gunssounds)\r\nscripts\item_defs\vehicles\common\gun_reload_effects.xml\dualgun_reload115_152\r\n\r\nUpdate 4.06 [1.1.0.0]: Soundbanks to Wwise 2017.2.5, Soundbanks (new):  4.06</UpdateComment>
-        <Medias>
-          <Media URL="http://bigmods.relhaxmodpack.com/WoT/Medias/Pictures/Sounds_WWIIHWA_Guns_by_KT+Budyx69_Mod.png" MediaType="Picture" />
-        </Medias>
-      </Package>
-    </Packages>
-  </Package>
   <Package PackageName="Sounds_CrewVoices" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3dblllqjziay9rqd" Name="Crew Voices" Type="multi" Visible="True">
     <Description>Change the crew sounds</Description>
     <Medias>
@@ -915,39 +609,114 @@
       </Package>
     </Packages>
   </Package>
-  <Package PackageName="Sounds_Kill" Enabled="True" InstallGroup="4" PatchGroup="4" UID="md04inxebx92bxil" Name="Kill (UT Announcer)" Type="multi" Visible="True">
-    <Timestamp>131848541900323120</Timestamp>
-    <DevURL>http://forum.worldoftanks.eu/index.php?/topic/557716-</DevURL>
-    <Description>UT Countdown:\nPlays certain sounds for when you get a certain number of kills in the game.</Description>
+  <Package PackageName="Sounds_Engine" Enabled="True" InstallGroup="4" PatchGroup="4" UID="j1ezivwfk4sogzg5" Name="Engine" Type="multi" Visible="True">
+    <Dependencies>
+      <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
+    </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_Kill_UTAnnouncer" Enabled="True" InstallGroup="4" PatchGroup="4" UID="gsibarnw6gbrmq0y" Name="UT Countdown" Type="single1" Visible="True">
-        <Size>1640947</Size>
-        <ZipFile>Sounds_Kill_UT_Announcer_base_1.7.0.0_2019-12-11.zip</ZipFile>
-        <CRC>58e9f52c4af4d6e9bc41106bac18c281</CRC>
-        <Timestamp>132205738457976411</Timestamp>
-        <DevURL>http://dieschwarzenschafe.com/download/</DevURL>
-        <PopularMod>True</PopularMod>
-        <ObfuscatedMod>True</ObfuscatedMod>
-        <Packages>
-          <Package PackageName="Sounds_Kill_UTAnnouncer_Locastan" Enabled="True" InstallGroup="4" PatchGroup="4" UID="thoqiqtx6c39m17y" Name="Locastan original config" Type="single_dropdown1" Visible="True">
-            <Size>3060</Size>
-            <ZipFile>Sounds_Kill_UT_Announcer_Locastan_2019-06-26.zip</ZipFile>
-            <CRC>14d579b0c661de36a1d4d72e33bf5243</CRC>
-            <Timestamp>132157901330301792</Timestamp>
-          </Package>
-          <Package PackageName="Sounds_Kill_UTAnnouncer_Only_3_min_warning" Enabled="True" InstallGroup="4" PatchGroup="4" UID="66v5qqzy59wrmdey" Name="Only 3 min warning config" Type="single_dropdown1" Visible="True">
-            <Size>2420</Size>
-            <ZipFile>Sounds_Kill_UT_Announcer_Only_3_min_warning_2019-06-26.zip</ZipFile>
-            <CRC>48405042a14b5649e7ef63c1fbfdfab6</CRC>
-            <Timestamp>132060125166625397</Timestamp>
-          </Package>
-          <Package PackageName="Sounds_Kill_UTAnnouncer_Webium" Enabled="True" InstallGroup="4" PatchGroup="4" UID="0kcciuph0sygy6wb" Name="Webium config" Type="single_dropdown1" Visible="True">
-            <Size>3040</Size>
-            <ZipFile>Sounds_Kill_UT_Announcer_Webium_2019-06-26.zip</ZipFile>
-            <CRC>5750fa9c055a5837fc949fa21a672d8b</CRC>
-            <Timestamp>132157901590510487</Timestamp>
-          </Package>
-        </Packages>
+      <Package PackageName="Sounds_AGQJ_Engines_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ Engines by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
+        <Size>8141</Size>
+        <Version>234</Version>
+        <ZipFile>Sounds_AGQJ_Engines_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>ee7fe89423b7a52dc1a0ef08152707ff</CRC>
+        <Timestamp>132321454605017775</Timestamp>
+        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
+        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
+        <UpdateComment>T10 Fix"V-12-6": \r\n{                "wwsoundPC": "V_12P",\r\n                "wwsoundNPC": "V_12P_NPC"           },\r\n\r\nUpdate  G&amp;M  V230  ( 04.03.2020 )</UpdateComment>
+        <Dependencies>
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_AGQJ_Engines_Fedor_Saveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ Engines by Fedor Saveliev" Type="single_dropdown1" Visible="True">
+        <Size>22014</Size>
+        <Version>1.9.0.0</Version>
+        <ZipFile>Sounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_Mister_bl_614_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>af6ac123ab4eb60423ffd936e9152ee3</CRC>
+        <Timestamp>132327454379581360</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
+        <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
+        <Dependencies>
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Engines_by_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
+        <Size>21658356</Size>
+        <Version>1.2.0.1</Version>
+        <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.2.0.1_2018-10-18.zip</ZipFile>
+        <CRC>942fcf6e4b5137d576aecdcb13f9675b</CRC>
+        <Timestamp>131843677273540576</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
+        <InternalNotes> (no original files by WG as template)</InternalNotes>
+        <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
+        <UpdateComment>1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
+        <Medias>
+          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Engines_HRMOD_GnomeFather_Zorgane" Enabled="True" InstallGroup="4" PatchGroup="4" UID="x8q7i2oj8zh328uv" Name="GnomeFather’s HRMOD Engines Sounds (reworked by Zorgane)  v{version}" Type="single_dropdown1" Visible="True">
+        <Size>3065</Size>
+        <Version>3.00</Version>
+        <ZipFile>Sounds_Engines_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
+        <CRC>9622f81b69bb2ad67409094a9928769e</CRC>
+        <Timestamp>132325073809233568</Timestamp>
+        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
+        <InternalNotes>own soundbanks by Zorgane:\naudioww\Zorg_Guns_Engines.bnk\naudioww\Zorg_Guns_Engines.pck\n\nmoded scripts\nscripts\item_defs\vehicles\r\n\r\nhttps://www.mediafire.com/folder/dh5bf45314xfo/Gnomefather's_HRMOD</InternalNotes>
+        <Description>Dont forget : I (Zorgane) need reviews ! - use devolper website to do this please\n\nNote : Scripts for remodels are unavailable for the moment.</Description>
+        <UpdateComment>V. 2.18 Added FV/T95 custom sounds\r\nFixed german HL234 engine\r\n\r\nV. 2.16 Fixed scripts for xmas style\r\nFixed Panther turbo engine sound\r\nFixed missing french engine sounds\r\n\r\nV.2.15: Added engine sounds for some american tanks\r\nV.2.14: Added support for Super Hellcat\r\n\r\nV. 2.10 Patchnote Compatibility with 1.6.0.2\r\nFixed leopard engine sound\r\nFixed T-116 gun sound\r\nAdded 64bit memory profile\r\n</UpdateComment>
+        <Medias>
+          <Media URL="http://image.noelshack.com/fichiers/2017/20/1495072185-config.jpg" MediaType="Picture" />
+          <Media URL="https://youtu.be/V7G2JDB07Lw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_AGQJ_Engines_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+        <Size>83692900</Size>
+        <Version>1.2.0.0</Version>
+        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.2.0_2018-10-12.zip</ZipFile>
+        <CRC>f81a45d6cad2f9baa0d9eb0b4503681d</CRC>
+        <Timestamp>131774181890246272</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
+      </Package>
+      <Package PackageName="Sounds_AGQJ_Engines" Enabled="False" InstallGroup="4" PatchGroup="4" UID="4ceui5k32fbaedj8" Name="AGQJ Engines by Fedor Saveliev  v{version}" Type="single_dropdown1" Visible="False">
+        <Size>83692297</Size>
+        <Version>1.5.0.2</Version>
+        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.2_2019-05-15.zip</ZipFile>
+        <CRC>704f4f3656a7356f17c0f1f44a009ef9</CRC>
+        <Timestamp>131940420589802487</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes> (no original files by WG as template)</InternalNotes>
+        <Description>direct link:Engines  (no SoundEventInjector)\nhttps://yadi.sk/d/mqjb17bGynH6V\n\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Engines_by_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="h1k8q4q42b3sepq8" Name="NOTES: Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
+        <Size>21654503</Size>
+        <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.1.0_2018-08-31.zip</ZipFile>
+        <CRC>dfb5e70f2e91630d08e92fc01ff0d1ea</CRC>
+        <Timestamp>131838128329867008</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>
+        <InternalNotes>Dont use PYmods_BanksLoader with WWIIHWA: \n- Sound Event Injector is incompatible with WWIIHWA\n- "WoT-Circle": Restart -&gt; Crash -&gt; Restart -&gt; Crash....)\nSound Event Injector : \n- great tool for modding sounds \n- no patches are needed \n- updating get much easier &amp; faster</InternalNotes>
+        <Description>Sound Event Injector : \n\nWillster: \nI dont know what we do with tthe Sound Event Injector Versions (script-file)\nBank-loader isnt used here &amp; In Relhax - not necessary \n- take audio.xml/engine.config.xml\n\n (no original files by WG as template)</Description>
+        <Medias>
+          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
       </Package>
     </Packages>
   </Package>
@@ -1006,6 +775,237 @@
         <CRC>933d133e6a49f947c5d9e2aeb34b531b</CRC>
         <Timestamp>132008674255753306</Timestamp>
         <Description>Will add WEEEE sound when loading into a battle in a wheeled tank.</Description>
+      </Package>
+    </Packages>
+  </Package>
+  <Package PackageName="Sounds_GUI" Enabled="True" InstallGroup="4" PatchGroup="4" UID="uqrny4w518w9e0y8" Name="GUI" Type="multi" Visible="True">
+    <Packages>
+      <Package PackageName="Sounds_GUI_Relhax" Enabled="True" InstallGroup="4" PatchGroup="4" UID="o49vq8mowrxzptgl" Name="Relhax by Willster419" Type="single_dropdown1" Visible="True">
+        <Size>35069225</Size>
+        <ZipFile>Sounds_GUI_Sounds_Relhax_2019-07-21.zip</ZipFile>
+        <CRC>7c7bbcb6b31c32be3be546fe7b600813</CRC>
+        <Timestamp>132082299682684028</Timestamp>
+        <Medias>
+          <Media URL="http://i.imgur.com/uWih1kD.jpg" MediaType="Picture" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+    </Packages>
+  </Package>
+  <Package PackageName="Sounds_Gun" Enabled="True" InstallGroup="4" PatchGroup="4" UID="1tfay7spvnqhp5nl" Name="Gun" Type="multi" Visible="True">
+    <Dependencies>
+      <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
+    </Dependencies>
+    <Packages>
+      <Package PackageName="Sounds_Gun_Star_Trek_Phaser" Enabled="True" InstallGroup="4" PatchGroup="4" UID="eimp66yqukiyphuk" Name="Star Trek Phasers by The Illusion v{version}" Type="single_dropdown1" Visible="True">
+        <Size>7744194</Size>
+        <Version>6.2831</Version>
+        <ZipFile>Sound_Mods_Gun_Sounds_The_Illusion_Star_Trek_Weapons_2019-05-04.zip</ZipFile>
+        <CRC>f588548e2b9dac3f8138cedd7c3607d5</CRC>
+        <DevURL>http://forum.worldoftanks.com/index.php?/topic/602970-1412-phaser-gun-sounds/</DevURL>
+        <Description>Changes all guns to be more phasery!</Description>
+        <UpdateComment>V6.2831 - Added to "Effects" volume slider\nV3.1415 Updated all sounds to be better quality</UpdateComment>
+      </Package>
+      <Package PackageName="Sounds_Gun_Wrath" Enabled="True" InstallGroup="4" PatchGroup="4" UID="8x3wxao9p3ko09cy" Name="Wrath Of The Gods by The Illusion v{version}" Type="single_dropdown1" Visible="True">
+        <Size>3747536</Size>
+        <Version>2.314</Version>
+        <ZipFile>Sound_Mods_Gun_Sounds_TheIllusion_Wrath_V2.314_1.5.1.1_2019-06-24.zip</ZipFile>
+        <CRC>b24279ceec70ddd7b0980d1876250489</CRC>
+        <Timestamp>132024199381905502</Timestamp>
+        <DevURL>http://forum.worldoftanks.com/index.php?/topic/604225-1501-wrath-of-the-gods-gun-sound-mod</DevURL>
+        <Description>This will make guns sound real. And scary....</Description>
+        <UpdateComment>V2.0 - Changed "NPC" Sounds to sound different, Changed 139mm+ guns sounds (Now will make you jump the first time....)</UpdateComment>
+        <Medias>
+          <Media URL="https://youtu.be/J3v3TZhLk4I" MediaType="Webpage" />
+        </Medias>
+      </Package>
+      <Package PackageName="Sounds_Gun_9.13" Enabled="True" InstallGroup="4" PatchGroup="4" UID="lmab5auaozc60ljx" Name="_Violence_'s 0.9.13 Gun Sounds v{version}" Type="single_dropdown1" Visible="True">
+        <Size>2688534</Size>
+        <Version>1.0</Version>
+        <ZipFile>Sound_Gun_Sounds_By_Violence_1.4.1.1_2019-04-04.zip</ZipFile>
+        <CRC>92caf0d676d0f3e9f7e352d51da8157e</CRC>
+        <Timestamp>131988818715738838</Timestamp>
+        <DevURL>https://wgmods.net/3170/details</DevURL>
+        <Description>All sounds are inherited from the original WoT 0.9.13 client.\n\nCovered sounds: 45mm, 76mm, 100mm, 122mm, 152mm\n\nSorry, no autocannon sounds yet.</Description>
+      </Package>
+      <Package PackageName="Sounds_Gun_by_Shimada_Samas" Enabled="True" InstallGroup="4" PatchGroup="4" UID="f0rixektjievbe1b" Name="Gun Sounds by Shimada Samas" Type="single_dropdown1" Visible="True">
+        <Size>40928630</Size>
+        <Version>5.40</Version>
+        <ZipFile>Sound_Mods_Gun_by_Shimada_Samas_5.40_1.9.0.1_2020-04-26.zip</ZipFile>
+        <CRC>8a90413f14a768289cfcb9887c4977c6</CRC>
+        <Timestamp>132323646945848449</Timestamp>
+        <DevURL>https://wgmods.net/673/details</DevURL>
+        <Description>Gun Sounds by Shimada Samas /  _Shimada_Arisu_ \nI use gun sound from many source such as\n- Gnomefather\n- Battlefield\n- WarThunder\nand more.</Description>
+        <UpdateComment>Version 5.3.3 (2020-03-16)\r\n- Update for 1.8.0.1\r\n\r\nVersion 5.3.2 (2020-03-14)\r\n- Update for 1.8.0.0\r\nVersion 5.3.0\r\n- Update for 1.7.1.2 - Add gun sounds for double gun tanks\r\nVersion 5.20 (2020-01-13)\r\n- Update for 1.7.0.2 \r\n- Fix a 3D style skin bug for Jg.Pz.E100 and AMX 13 105 - Update Jg.Pz.E100 and AMX 13 105 script files</UpdateComment>
+        <Medias>
+          <Media URL="https://youtu.be/Pe5njjXegUM?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/kqOTdQ9OlIw?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+      </Package>
+      <Package PackageName="Sounds_Gun_HRMOD_GnomeFather_Zorgane" Enabled="True" InstallGroup="4" PatchGroup="4" UID="spyx5dquif6dbq8a" Name="GnomeFather’s HRMOD Gun Sounds (reworked by Zorgane)  v{version}" Type="single_dropdown1" Visible="True">
+        <Size>15787</Size>
+        <Version>3.00</Version>
+        <ZipFile>Sounds_Gun_HRMOD_GnomeFather_Zorgane_SCRIPTS_1.9.0.1_2020-04-27.zip</ZipFile>
+        <CRC>814cbe031b312a74130c53ed6c1358d6</CRC>
+        <Timestamp>132325074171114003</Timestamp>
+        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
+        <InternalNotes>These are now wotmods for conflicting reasons.\r\n\r\nown soundbanks by Zorgane:\naudioww\Zorg_Guns_Engines.bnk\naudioww\Zorg_Guns_Engines.pck\n\nmoded scripts\nscripts\item_defs\vehicles\r\n\r\nhttps://www.mediafire.com/folder/dh5bf45314xfo/Gnomefather's_HRMOD</InternalNotes>
+        <Description>This mod alters the sounds via the tanks xml's. This makes the mod break every patch. Expect some time for updates. Use Wrath of the Gods gun sounds, or Shimada if you want something that doesnt break every patch.\r\n\r\nDont forget : I (Zorgane) need reviews ! - use devolper website to do this please\n\n</Description>
+        <UpdateComment>V. 2.18 Added FV/T95 custom sounds\r\nFixed german HL234 engine\r\n\r\nV. 2.16 Fixed scripts for xmas style\r\nFixed Panther turbo engine sound\r\nFixed missing french engine sounds\r\n\r\nV.2.15: Added engine sounds for some american tanks\r\nV.2.14: Added support for Super Hellcat\r\n\r\nV. 2.10 Patchnote Compatibility with 1.6.0.2\r\nFixed leopard engine sound\r\nFixed T-116 gun sound\r\nAdded 64bit memory profile</UpdateComment>
+        <Medias>
+          <Media URL="http://image.noelshack.com/fichiers/2017/20/1495072185-config.jpg" MediaType="Picture" />
+          <Media URL="&lt;html&gt;&lt;head&gt;&lt;meta http-equiv='X-UA-Compatible' content='IE=11' /&gt;&lt;body&gt;&lt;iframe width=&quot;640&quot; height=&quot;360&quot; src=&quot;https://www.youtube.com/embed/V7G2JDB07Lw&quot; frameborder=&quot;0&quot; style=&quot;position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;&quot;&gt; Your browser doesn't support iFrames.&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" MediaType="HTML" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_AGQJ_Guns_by_Fedor_Saveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ Guns by Fedor Saveliev" Type="single_dropdown1" Visible="True">
+        <Size>13133</Size>
+        <Version>1.9.0.0</Version>
+        <ZipFile>Sounds_AGQJ_Guns_by_FedorSaveliev_Only_Scripts_Mister_bl#614_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>1474a259478ddf461842fcc4a3f56dea</CRC>
+        <Timestamp>132321437159757811</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
+        <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_AGQJ_Guns_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ Guns by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
+        <Size>15995</Size>
+        <Version>234</Version>
+        <ZipFile>Sounds_AGQJ_Guns_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>b1af5ec72469a38d2283313e81b0ed7c</CRC>
+        <Timestamp>132321453467109357</Timestamp>
+        <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
+        <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
+        <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Gun_AGQJ_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="chtydgsecrt2m65n" Name="NOTES: AGQJ Gun Sounds by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+        <Size>95845585</Size>
+        <Version>1502</Version>
+        <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_1.5.0.2_2019-05-18.zip</ZipFile>
+        <CRC>8ac233a3e08255f8865e948239456cbb</CRC>
+        <Timestamp>132207969933092634</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
+        <Description>Editor test: Hallo Relhax V2 - grown up from childish beta status</Description>
+      </Package>
+      <Package PackageName="Sounds_Gun_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="p6zdlfyfbnlkmicn" Name="AGQJ Gun Sounds by Fedor Saveliev v{version} (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+        <Size>95868116</Size>
+        <Version>1.5.0.1</Version>
+        <ZipFile>Sounds_AGQJ_Gun_Sounds_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.1_2019-05-14.zip</ZipFile>
+        <CRC>2974ae69a73c8aa52f85a69ce016f6ab</CRC>
+        <Timestamp>131838144585727822</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes> (no original files by WG as template)</InternalNotes>
+        <Description>direct link :Gun_sounds (no SoundEventInjector)\nhttps://yadi.sk/d/GNoG0AI5sRcaq\n\ndirect link :Gun_sounds (SoundEventInjector)\nhttps://yadi.sk/d/2uTYjByN3TamTd\r\n\r\nmaybe confict with WWIIHWA</Description>
+        <Medias>
+          <Media URL="https://youtu.be/CUs8Z42fAK0?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/XN8A0MRqw0E?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/aS_Y26uJ0SA?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/l8Kd4KuvZFg?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/5bKlYtpVTuI?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/b9Uy9Qs7kGA?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/P9ISUHoYKMY?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/JpUQhbF2Tc8?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/EiNfm2AmBQY?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+          <Media URL="https://youtu.be/5EtBFvWcNQk?version=3&amp;amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="jlhkdjoy66n9ybu0" Name="Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
+        <Size>34292701</Size>
+        <Version>1.8.0.0</Version>
+        <ZipFile>Sounds_Gun_GO_by_Ed76na+Apa6ecka_1.8.0.0_2020-03-04.zip</ZipFile>
+        <CRC>1b23db178c16b8eba059cd454b53c146</CRC>
+        <Timestamp>132278011144054309</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-\r\nhttps://drive.google.com/drive/folders/1T1gp79ZIifkhrU0WRfcInbhfQfiVVlIg</DevURL>
+        <InternalNotes> (no original files by WG as template)</InternalNotes>
+        <Description>With Sound Event Injector; \n- great tool for modding sounds \n- no patches for the Events are needed \n\nNo PYmods_BanksLoader - only Patches to engine_config.xml\n\nUsable with WWIIHWA (no Bankloader - Patches used)\n- Sound Event Injector is compatible with WWIIHWA</Description>
+        <UpdateComment>2019-04-16: added HWK30, TS-5\n1412=1.2.0 = 1.1.0; 1.1.0.0: Soundbanks to Wwise 2017.2.5, new Soundbanks</UpdateComment>
+        <Medias>
+          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+        <Dependencies>
+          <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
+          <Dependency PackageName="Dependency_PYmods_SoundEventInjector" NotFlag="False" Logic="OR" />
+        </Dependencies>
+      </Package>
+      <Package PackageName="Sounds_Gun_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="wanzliuz53grxm10" Name="NOTES: Gun Sounds by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
+        <Size>34224145</Size>
+        <Timestamp>131701182641902565</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/842096-</DevURL>
+        <InternalNotes>Dont use this version(PYmods_BanksLoader) with WWIIHWA: \n- Sound Event Injector is incompatible with WWIIHWA\n- "WoT-Circle": Restart -&gt; Crash -&gt; Restart -&gt; Crash....)\nSound Event Injector : \n- great tool for modding sounds \n- no patches are needed \n- updating get much easier &amp; faster</InternalNotes>
+        <Description>Sound Event Injector : \n\nWillster: \nI dont know what we do with tthe Sound Event Injector Versions (script-file)\nBank-loader isnt used here &amp; In Relhax - not necessary \n- take audio.xml/engine.config.xml\n\n (no original files by WG as template)</Description>
+        <Medias>
+          <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
+        </Medias>
+      </Package>
+      <Package PackageName="Sounds_WWIIHWA_Guns_by_KT+Budyx69" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds by Budyx69 &amp; KT " Type="single_dropdown1" Visible="True">
+        <Size>15210784</Size>
+        <Version>4.09</Version>
+        <ZipFile>Sounds_WWIIHWA_Gunsounds_v4.09_1.7.1.0_2020-01-29.zip</ZipFile>
+        <CRC>f478eb4c26bb7bbfaa678102147d77fe</CRC>
+        <Timestamp>132248036037116996</Timestamp>
+        <DevURL>https://dieschwarzenschafe.com/download/Index.php?action=list&amp;dir=WWIIHWA%2FWWIIHWA+GunSounds&amp;order=name&amp;srt=yes\r\nhttp://forum.worldoftanks.eu/index.php?/topic/502495-</DevURL>
+        <UpdateComment>Update 4.07 [1.6.1.0]:  DualGunReload topic (maybe usefull for other gunssounds)\r\nscripts\item_defs\vehicles\common\gun_reload_effects.xml\dualgun_reload115_152\r\n\r\nUpdate 4.06 [1.1.0.0]: Soundbanks to Wwise 2017.2.5, Soundbanks (new):  4.06</UpdateComment>
+        <Medias>
+          <Media URL="http://bigmods.relhaxmodpack.com/WoT/Medias/Pictures/Sounds_WWIIHWA_Guns_by_KT+Budyx69_Mod.png" MediaType="Picture" />
+        </Medias>
+      </Package>
+    </Packages>
+  </Package>
+  <Package PackageName="Sounds_Kill" Enabled="True" InstallGroup="4" PatchGroup="4" UID="md04inxebx92bxil" Name="Kill (UT Announcer)" Type="multi" Visible="True">
+    <Timestamp>131848541900323120</Timestamp>
+    <DevURL>http://forum.worldoftanks.eu/index.php?/topic/557716-</DevURL>
+    <Description>UT Countdown:\nPlays certain sounds for when you get a certain number of kills in the game.</Description>
+    <Packages>
+      <Package PackageName="Sounds_Kill_UTAnnouncer" Enabled="True" InstallGroup="4" PatchGroup="4" UID="gsibarnw6gbrmq0y" Name="UT Countdown" Type="single1" Visible="True">
+        <Size>1640947</Size>
+        <ZipFile>Sounds_Kill_UT_Announcer_base_1.7.0.0_2019-12-11.zip</ZipFile>
+        <CRC>58e9f52c4af4d6e9bc41106bac18c281</CRC>
+        <Timestamp>132205738457976411</Timestamp>
+        <DevURL>http://dieschwarzenschafe.com/download/</DevURL>
+        <PopularMod>True</PopularMod>
+        <ObfuscatedMod>True</ObfuscatedMod>
+        <Packages>
+          <Package PackageName="Sounds_Kill_UTAnnouncer_Locastan" Enabled="True" InstallGroup="4" PatchGroup="4" UID="thoqiqtx6c39m17y" Name="Locastan original config" Type="single_dropdown1" Visible="True">
+            <Size>3060</Size>
+            <ZipFile>Sounds_Kill_UT_Announcer_Locastan_2019-06-26.zip</ZipFile>
+            <CRC>14d579b0c661de36a1d4d72e33bf5243</CRC>
+            <Timestamp>132157901330301792</Timestamp>
+          </Package>
+          <Package PackageName="Sounds_Kill_UTAnnouncer_Only_3_min_warning" Enabled="True" InstallGroup="4" PatchGroup="4" UID="66v5qqzy59wrmdey" Name="Only 3 min warning config" Type="single_dropdown1" Visible="True">
+            <Size>2420</Size>
+            <ZipFile>Sounds_Kill_UT_Announcer_Only_3_min_warning_2019-06-26.zip</ZipFile>
+            <CRC>48405042a14b5649e7ef63c1fbfdfab6</CRC>
+            <Timestamp>132060125166625397</Timestamp>
+          </Package>
+          <Package PackageName="Sounds_Kill_UTAnnouncer_Webium" Enabled="True" InstallGroup="4" PatchGroup="4" UID="0kcciuph0sygy6wb" Name="Webium config" Type="single_dropdown1" Visible="True">
+            <Size>3040</Size>
+            <ZipFile>Sounds_Kill_UT_Announcer_Webium_2019-06-26.zip</ZipFile>
+            <CRC>5750fa9c055a5837fc949fa21a672d8b</CRC>
+            <Timestamp>132157901590510487</Timestamp>
+          </Package>
+        </Packages>
       </Package>
     </Packages>
   </Package>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -617,9 +617,9 @@
       <Package PackageName="Sounds_Engines_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ Engines by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
         <Size>8141</Size>
         <Version>234</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>ee7fe89423b7a52dc1a0ef08152707ff</CRC>
-        <Timestamp>132321454605017775</Timestamp>
+        <ZipFile>Sounds_Engines_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353109714656692</Timestamp>
         <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
         <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>
         <UpdateComment>T10 Fix"V-12-6": \r\n{                "wwsoundPC": "V_12P",\r\n                "wwsoundNPC": "V_12P_NPC"           },\r\n\r\nUpdate  G&amp;M  V230  ( 04.03.2020 )</UpdateComment>
@@ -632,9 +632,9 @@
       <Package PackageName="Sounds_Engines_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ Engines by Fedor Saveliev" Type="single_dropdown1" Visible="True">
         <Size>22014</Size>
         <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_Mister_bl_614_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>af6ac123ab4eb60423ffd936e9152ee3</CRC>
-        <Timestamp>132327454379581360</Timestamp>
+        <ZipFile>Sounds_Engines_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353110299441130</Timestamp>
         <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
         <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds</InternalNotes>
         <Description>AGQJ_Engines_Fedor_Saveliev\ndirect link:Engines  (SoundEventInjector)\nhttps://yadi.sk/d/JyTOJmcq3S9bLf\r\n\r\nmaybe confict with WWIIHWA</Description>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -609,12 +609,12 @@
       </Package>
     </Packages>
   </Package>
-  <Package PackageName="Sounds_Engine" Enabled="True" InstallGroup="4" PatchGroup="4" UID="j1ezivwfk4sogzg5" Name="Engine" Type="multi" Visible="True">
+  <Package PackageName="Sounds_Engines" Enabled="True" InstallGroup="4" PatchGroup="4" UID="j1ezivwfk4sogzg5" Name="Engines" Type="multi" Visible="True">
     <Dependencies>
       <Dependency PackageName="Dependency_Sounds_IncreaseSoundMemory_large" NotFlag="False" Logic="OR" />
     </Dependencies>
     <Packages>
-      <Package PackageName="Sounds_AGQJ_Engines_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ Engines by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="dgv6azmyfnuersyj" Name="AGQJ Engines by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
         <Size>8141</Size>
         <Version>234</Version>
         <ZipFile>Sounds_AGQJ_Engines_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
@@ -629,7 +629,7 @@
           <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_AGQJ_Engines_Fedor_Saveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ Engines by Fedor Saveliev" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="q52liyszekmvr45i" Name="AGQJ Engines by Fedor Saveliev" Type="single_dropdown1" Visible="True">
         <Size>22014</Size>
         <Version>1.9.0.0</Version>
         <ZipFile>Sounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_Mister_bl_614_1.9.0.0_2020-04-23.zip</ZipFile>
@@ -644,7 +644,7 @@
           <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Engines_by_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka" Enabled="True" InstallGroup="4" PatchGroup="4" UID="3u80qyy0dgfdrfci" Name="Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="True">
         <Size>21658356</Size>
         <Version>1.2.0.1</Version>
         <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.2.0.1_2018-10-18.zip</ZipFile>
@@ -683,16 +683,7 @@
           <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_AGQJ_Engines_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
-        <Size>83692900</Size>
-        <Version>1.2.0.0</Version>
-        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.2.0_2018-10-12.zip</ZipFile>
-        <CRC>f81a45d6cad2f9baa0d9eb0b4503681d</CRC>
-        <Timestamp>131774181890246272</Timestamp>
-        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
-        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
-      </Package>
-      <Package PackageName="Sounds_AGQJ_Engines" Enabled="False" InstallGroup="4" PatchGroup="4" UID="4ceui5k32fbaedj8" Name="AGQJ Engines by Fedor Saveliev  v{version}" Type="single_dropdown1" Visible="False">
+      <Package PackageName="Sounds_Engines_AGQJ" Enabled="False" InstallGroup="4" PatchGroup="4" UID="4ceui5k32fbaedj8" Name="AGQJ Engines by Fedor Saveliev  v{version}" Type="single_dropdown1" Visible="False">
         <Size>83692297</Size>
         <Version>1.5.0.2</Version>
         <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.5.0.2_2019-05-15.zip</ZipFile>
@@ -706,7 +697,16 @@
           <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_Engines_by_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="h1k8q4q42b3sepq8" Name="NOTES: Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
+      <Package PackageName="Sounds_Engines_AGQJ_with_Soundinjektor_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="axwmq1uk8w9k2k1v" Name="NOTES: AGQJ Engines by Fedor Saveliev (SoundEventInjector)" Type="single_dropdown1" Visible="False">
+        <Size>83692900</Size>
+        <Version>1.2.0.0</Version>
+        <ZipFile>Sounds_AGQJ_Engines_by_Fedor_Saveliev_SoundEventInjector_PYmodsCore_1.2.0_2018-10-12.zip</ZipFile>
+        <CRC>f81a45d6cad2f9baa0d9eb0b4503681d</CRC>
+        <Timestamp>131774181890246272</Timestamp>
+        <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
+        <InternalNotes>0. Soundinjektor is a great tool for modding sounds - no Patches are needed - updating gets much easier\n1. Problem: Working alone as intended check replays\n2. Problem: Soundinjektor is incompatible with WWIIHWA (WOT-Circle -- restart-&gt;crash-&gt;restart-&gt;crash....)\n3. Dont have Ideas/ muse / moods  for fixing now -123gauss</InternalNotes>
+      </Package>
+      <Package PackageName="Sounds_Engines_Ed76na+Apa6ecka_NOTES" Enabled="False" InstallGroup="4" PatchGroup="4" UID="h1k8q4q42b3sepq8" Name="NOTES: Engines by Ed76na &amp; Apa6ecka" Type="single_dropdown1" Visible="False">
         <Size>21654503</Size>
         <ZipFile>Sounds_Engines_GO_by_Ed76na+Apa6ecka_1.1.0_2018-08-31.zip</ZipFile>
         <CRC>dfb5e70f2e91630d08e92fc01ff0d1ea</CRC>
@@ -769,7 +769,7 @@
           <Media URL="https://bigmods.relhaxmodpack.com/Medias/Pictures/sound_mods/extras/explorer_22JSs8tEKx.jpg" MediaType="Picture" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_WheeledTankLoaded" Enabled="False" InstallGroup="4" PatchGroup="4" UID="sjmim7ze2g2xhfe2" Name="Wheeled Tank Loading" Type="multi" Visible="False">
+      <Package PackageName="Sounds_Extras_WheeledTankLoaded" Enabled="False" InstallGroup="4" PatchGroup="4" UID="sjmim7ze2g2xhfe2" Name="Wheeled Tank Loading" Type="multi" Visible="False">
         <Size>124166</Size>
         <ZipFile>Sound_Mods_Wheeled_Joke_2019-04-27.zip</ZipFile>
         <CRC>933d133e6a49f947c5d9e2aeb34b531b</CRC>
@@ -865,7 +865,7 @@
           <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_AGQJ_Guns_by_Fedor_Saveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ Guns by Fedor Saveliev" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ Guns by Fedor Saveliev" Type="single_dropdown1" Visible="True">
         <Size>13133</Size>
         <Version>1.9.0.0</Version>
         <ZipFile>Sounds_AGQJ_Guns_by_FedorSaveliev_Only_Scripts_Mister_bl#614_1.9.0.0_2020-04-23.zip</ZipFile>
@@ -880,7 +880,7 @@
           <Dependency PackageName="Dependency_PYmodsCore" NotFlag="False" Logic="OR" />
         </Dependencies>
       </Package>
-      <Package PackageName="Sounds_AGQJ_Guns_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ Guns by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ Guns by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
         <Size>15995</Size>
         <Version>234</Version>
         <ZipFile>Sounds_AGQJ_Guns_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
@@ -959,7 +959,7 @@
           <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_WWIIHWA_Guns_by_KT+Budyx69" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds by Budyx69 &amp; KT " Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_WWIIHWA_by_KT+Budyx69" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds by Budyx69 &amp; KT " Type="single_dropdown1" Visible="True">
         <Size>15210784</Size>
         <Version>4.09</Version>
         <ZipFile>Sounds_WWIIHWA_Gunsounds_v4.09_1.7.1.0_2020-01-29.zip</ZipFile>

--- a/latest_database/SoundMods.xml
+++ b/latest_database/SoundMods.xml
@@ -868,9 +868,9 @@
       <Package PackageName="Sounds_Gun_AGQJ_FedorSaveliev" Enabled="True" InstallGroup="4" PatchGroup="4" UID="5e5cdcwvibzvb1fa" Name="AGQJ Guns by Fedor Saveliev" Type="single_dropdown1" Visible="True">
         <Size>13133</Size>
         <Version>1.9.0.0</Version>
-        <ZipFile>Sounds_AGQJ_Guns_by_FedorSaveliev_Only_Scripts_Mister_bl#614_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>1474a259478ddf461842fcc4a3f56dea</CRC>
-        <Timestamp>132321437159757811</Timestamp>
+        <ZipFile>Sounds_Gun_AGQJ_FedorSaveliev_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353106271010963</Timestamp>
         <DevURL>http://forum.worldoftanks.ru/index.php?/topic/1778752-</DevURL>
         <InternalNotes>Guderian__1979 (Apr 7, 2020 - 19:09) wrote: post 612 page 31\r\nThe topic is permanently closed\r\n\r\nnot working: \r\nSounds_AGQJ_Engines_by_FedorSaveliev_Only_Scripts_N_E_L_U_M_B_O_1.9.0.0_2020-04-22.zip \r\nor gun sounds\r\n\r\nDependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
         <UpdateComment>2019-12-11: added GO_reload.wotmod</UpdateComment>
@@ -883,9 +883,9 @@
       <Package PackageName="Sounds_Gun_AGQJ_SicFunzler" Enabled="True" InstallGroup="4" PatchGroup="4" UID="zsmj5gmdcu1kmuxn" Name="AGQJ Guns by SicFunzler v{version}" Type="single_dropdown1" Visible="True">
         <Size>15995</Size>
         <Version>234</Version>
-        <ZipFile>Sounds_AGQJ_Guns_by_SicFunzler_Only_Scripts_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-        <CRC>b1af5ec72469a38d2283313e81b0ed7c</CRC>
-        <Timestamp>132321453467109357</Timestamp>
+        <ZipFile>Sounds_Gun_AGQJ_SicFunzler_v234_1.9.0.0_2020-04-23.zip</ZipFile>
+        <CRC>f</CRC>
+        <Timestamp>132353106348541606</Timestamp>
         <DevURL>http://forum.worldoftanks.eu/index.php?/topic/432265-</DevURL>
         <InternalNotes>Dependecy_Sounds_AGQJ_Guns_Soundbanks_V210_1.7.0.2_2019-12-27.zip\r\n=Dependecy_Sounds_AGQJ_Guns_Soundbanks_V230</InternalNotes>
         <UpdateComment>Update  G&amp;M  V230  ( 04.03.2020 )\r\n\r\nV210 (2019-12-27): double barrel guns working (OBJEKT 703 VERSION II)\r\n\r\n2019-12-11: added GO_reload.wotmod</UpdateComment>
@@ -959,13 +959,14 @@
           <Media URL="https://youtu.be/OLEcH5uEPRY?version=3&amp;autoplay=1" MediaType="Webpage" />
         </Medias>
       </Package>
-      <Package PackageName="Sounds_Gun_WWIIHWA_by_KT+Budyx69" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds by Budyx69 &amp; KT " Type="single_dropdown1" Visible="True">
+      <Package PackageName="Sounds_Gun_WWIIHWA" Enabled="True" InstallGroup="4" PatchGroup="4" UID="qo57dmki0mhg9fjd" Name="WWIIHWA Gunsounds [by  {author}]" Type="single_dropdown1" Visible="True">
         <Size>15210784</Size>
         <Version>4.09</Version>
         <ZipFile>Sounds_WWIIHWA_Gunsounds_v4.09_1.7.1.0_2020-01-29.zip</ZipFile>
         <CRC>f478eb4c26bb7bbfaa678102147d77fe</CRC>
         <Timestamp>132248036037116996</Timestamp>
         <DevURL>https://dieschwarzenschafe.com/download/Index.php?action=list&amp;dir=WWIIHWA%2FWWIIHWA+GunSounds&amp;order=name&amp;srt=yes\r\nhttp://forum.worldoftanks.eu/index.php?/topic/502495-</DevURL>
+        <Author>Budyx69 &amp; KT</Author>
         <UpdateComment>Update 4.07 [1.6.1.0]:  DualGunReload topic (maybe usefull for other gunssounds)\r\nscripts\item_defs\vehicles\common\gun_reload_effects.xml\dualgun_reload115_152\r\n\r\nUpdate 4.06 [1.1.0.0]: Soundbanks to Wwise 2017.2.5, Soundbanks (new):  4.06</UpdateComment>
         <Medias>
           <Media URL="http://bigmods.relhaxmodpack.com/WoT/Medias/Pictures/Sounds_WWIIHWA_Guns_by_KT+Budyx69_Mod.png" MediaType="Picture" />

--- a/latest_database/dependencies.xml
+++ b/latest_database/dependencies.xml
@@ -659,20 +659,20 @@
     <CRC>e262ac33f8bc4959a8142b10b95c3446</CRC>
     <Timestamp>132102553935222527</Timestamp>
   </Dependency>
-  <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" Enabled="True" InstallGroup="2" PatchGroup="2" UID="y9yafih97w6eccxp">
+  <Dependency PackageName="Dependency_Sounds_GnomeFathers_SoundBanks" Enabled="True" InstallGroup="6" PatchGroup="2" UID="y9yafih97w6eccxp">
     <Size>143231251</Size>
     <ZipFile>Dependency_GnomeFathers_SoundBanks_v3.00_1.9.0.1_2020-04-27.zip</ZipFile>
     <CRC>5de476bea81b25a0dff60de82680c00d</CRC>
     <Timestamp>132325073038892680</Timestamp>
     <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
   </Dependency>
-  <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" Enabled="True" InstallGroup="2" PatchGroup="2" UID="by4pnina7sywco5o">
+  <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" Enabled="True" InstallGroup="6" PatchGroup="2" UID="by4pnina7sywco5o">
     <Size>96202544</Size>
     <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_v234_1.9.0.0_2020-04-23.zip</ZipFile>
     <CRC>fad6c05a235dbd01f3a51b1ee72615f0</CRC>
     <Timestamp>132321503999678031</Timestamp>
   </Dependency>
-  <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" Enabled="True" InstallGroup="2" PatchGroup="2" UID="5dmxfmdt2b0lnhm2">
+  <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" Enabled="True" InstallGroup="6" PatchGroup="2" UID="5dmxfmdt2b0lnhm2">
     <Size>83686458</Size>
     <ZipFile>Dependecy_Sounds_AGQJ_Engines_Soundbanks_v234_1.9.0.0_2020-04-23.zip</ZipFile>
     <CRC>054d355020244615185062160d25f79d</CRC>

--- a/latest_database/dependencies.xml
+++ b/latest_database/dependencies.xml
@@ -678,28 +678,6 @@
     <CRC>054d355020244615185062160d25f79d</CRC>
     <Timestamp>132321472000821467</Timestamp>
   </Dependency>
-  <Dependency PackageName="Dependency_CrewVoices_English_Relhax" Enabled="True" InstallGroup="2" PatchGroup="2" UID="muyealiaz9e06heb">
-    <Size>1127</Size>
-    <Version>24</Version>
-    <ZipFile>Dependency_CrewVoices_English_Relhax_v24_2019-08-03.zip</ZipFile>
-    <CRC>833c22c8e5824ec90bacfe5daa96e1e5</CRC>
-    <Timestamp>132351638994661296</Timestamp>
-  </Dependency>
-  <Dependency PackageName="Dependency_CrewVoices_English_MLG" Enabled="True" InstallGroup="2" PatchGroup="2" UID="cg723zm9jas0utpg">
-    <Size>26113309</Size>
-    <ZipFile>Dependency_CrewVoices_English_MLG_1.7.1.0_2020-01-29.zip</ZipFile>
-    <CRC>0fa8fc8fe27c70bc966f480cde9cd8b1</CRC>
-    <Timestamp>132351643207337355</Timestamp>
-    <DevURL>http://forum.worldoftanks.eu/index.php?/topic/476721-</DevURL>
-  </Dependency>
-  <Dependency PackageName="Dependency_Sounds_Music_AndreVscripts" Enabled="True" InstallGroup="2" PatchGroup="2" UID="rludlms2cs6xqljf">
-    <Size>19007</Size>
-    <ZipFile>Dependency_Sounds_Music_AndreVscripts_2020-04-09.zip</ZipFile>
-    <CRC>3cc0f4eb650367e9b0e9b009db0929ac</CRC>
-    <Timestamp>132351662617163443</Timestamp>
-    <DevURL>https://wgmods.net/search/?owner=138375\r\nhttp://forum.worldoftanks.eu/index.php?/topic/672517-</DevURL>
-    <InternalNotes>Get the script files for the base pkg from any of Andre V's music mods. </InternalNotes>
-  </Dependency>
   <Dependency PackageName="--ShuraBB_AdvancedMinimap--" Enabled="False" InstallGroup="2" PatchGroup="2" UID="i2scnlju18s3ntu1">
     <CRC>f</CRC>
     <Timestamp>132309366281564769</Timestamp>

--- a/latest_database/dependencies.xml
+++ b/latest_database/dependencies.xml
@@ -666,18 +666,6 @@
     <Timestamp>132325073038892680</Timestamp>
     <DevURL>http://forum.worldoftanks.eu/index.php?/topic/596268-</DevURL>
   </Dependency>
-  <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Guns" Enabled="True" InstallGroup="6" PatchGroup="2" UID="by4pnina7sywco5o">
-    <Size>96202544</Size>
-    <ZipFile>Dependecy_Sounds_AGQJ_Guns_Soundbanks_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-    <CRC>fad6c05a235dbd01f3a51b1ee72615f0</CRC>
-    <Timestamp>132321503999678031</Timestamp>
-  </Dependency>
-  <Dependency PackageName="Dependency_Sounds_AGQJ_Soundbanks_Engines" Enabled="True" InstallGroup="6" PatchGroup="2" UID="5dmxfmdt2b0lnhm2">
-    <Size>83686458</Size>
-    <ZipFile>Dependecy_Sounds_AGQJ_Engines_Soundbanks_v234_1.9.0.0_2020-04-23.zip</ZipFile>
-    <CRC>054d355020244615185062160d25f79d</CRC>
-    <Timestamp>132321472000821467</Timestamp>
-  </Dependency>
   <Dependency PackageName="--ShuraBB_AdvancedMinimap--" Enabled="False" InstallGroup="2" PatchGroup="2" UID="i2scnlju18s3ntu1">
     <CRC>f</CRC>
     <Timestamp>132309366281564769</Timestamp>


### PR DESCRIPTION
This is the sound mods rework that started from https://github.com/Willster419/RelhaxModpackDatabase/commit/d7512da6a1f65088f3a0c33dc4e79caa6be3df50

The idea is that some mods like MLG and Relhax have configuration options, and by trying to flatten them in using the dropdowns, that configuration option is lost and must be a dependency. In an effort to reduce dependencies, I moved the `advanced` sound mods (just two for now) into their own `single1` group, while keeping the flat style of `basic` sound mods, like the other categories.

This method additionally keeps the original UIDs, a process that I would like to see kept as we move forward with this new database structure.

I haven't tested it fully yet, but I will later. Just starting this PR